### PR TITLE
docs/ts-bun-guide.md 추가 — TypeScript + Bun 개발환경 가이드

### DIFF
--- a/docs/ts-bun-guide
+++ b/docs/ts-bun-guide
@@ -1,10 +1,9 @@
 # TypeScript + Bun 개발환경 가이드
-
 ## 배경
-
 웹 브라우저와 독립적인 JS 개발(CLI, 백엔드)의 표준 런타임은 **Node.js**입니다.
 TypeScript를 직접 실행할 수 있는 런타임으로는 **Deno**와 **Bun**이 있으며, 이 프로젝트는 **Bun**을 사용합니다.
 ---
+
 ## 개발환경 (Codespaces 기준)
 
 이 프로젝트는 GitHub Codespaces를 기본 개발환경으로 사용합니다.
@@ -14,15 +13,11 @@ TypeScript를 직접 실행할 수 있는 런타임으로는 **Deno**와 **Bun**
 
 ```json
 {
-  "name": "reposcore-ts",
-  "features": {
-    "ghcr.io/devcontainers-extra/features/bun:1": {}
-  },
-  "postCreateCommand": "bun install",
   "customizations": {
     "vscode": {
       "extensions": [
         "oven.bun-vscode",
+        "ms-vscode.vscode-typescript-next",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "EditorConfig.EditorConfig"
@@ -32,17 +27,12 @@ TypeScript를 직접 실행할 수 있는 런타임으로는 **Deno**와 **Bun**
 }
 ```
 
-| 항목 | 설명 |
-|------|------|
-| `features` | Codespaces 컨테이너 빌드 시 Bun을 자동으로 설치 |
-| `postCreateCommand` | 컨테이너 생성 후 `bun install`을 자동 실행하여 의존성 설치 |
-| `extensions` | VSCode 확장 자동 설치 (아래 표 참고) |
-
 ### 자동 설치되는 VSCode 확장
 
 | 확장 ID | 역할 |
 |---------|------|
 | `oven.bun-vscode` | Bun 런타임 지원 및 디버거. TypeScript 파일 실행·디버그, 테스트 결과 인라인 표시, 실행 중 오류 위치를 에디터에서 바로 확인 |
+| `ms-vscode.vscode-typescript-next` | TypeScript nightly 빌드 적용. 최신 TypeScript 기능을 안정 릴리즈 전에 사용 가능 |
 | `dbaeumer.vscode-eslint` | ESLint를 VSCode에 통합. 코드 작성 중 린팅 오류를 밑줄/경고로 표시하고 Quick Fix로 자동 수정 |
 | `esbenp.prettier-vscode` | 파일 저장 시 코드 스타일 자동 정리 (들여쓰기, 따옴표, 세미콜론 등) |
 | `EditorConfig.EditorConfig` | `.editorconfig` 파일을 읽어 에디터 설정을 자동으로 적용. 팀원 간 불필요한 diff 방지 |

--- a/docs/ts-bun-guide
+++ b/docs/ts-bun-guide
@@ -1,0 +1,105 @@
+# TypeScript + Bun 개발환경 가이드
+
+## 배경
+
+웹 브라우저와 독립적인 JS 개발(CLI, 백엔드)의 표준 런타임은 **Node.js**입니다.
+TypeScript를 직접 실행할 수 있는 런타임으로는 **Deno**와 **Bun**이 있으며, 이 프로젝트는 **Bun**을 사용합니다.
+---
+## 개발환경 (Codespaces 기준)
+
+이 프로젝트는 GitHub Codespaces를 기본 개발환경으로 사용합니다.
+`.devcontainer/devcontainer.json`에 정의된 설정에 따라 Codespaces 진입 시 Bun 설치와 VSCode 확장이 **자동으로** 구성됩니다.
+
+### devcontainer.json
+
+```json
+{
+  "name": "reposcore-ts",
+  "features": {
+    "ghcr.io/devcontainers-extra/features/bun:1": {}
+  },
+  "postCreateCommand": "bun install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "oven.bun-vscode",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "EditorConfig.EditorConfig"
+      ]
+    }
+  }
+}
+```
+
+| 항목 | 설명 |
+|------|------|
+| `features` | Codespaces 컨테이너 빌드 시 Bun을 자동으로 설치 |
+| `postCreateCommand` | 컨테이너 생성 후 `bun install`을 자동 실행하여 의존성 설치 |
+| `extensions` | VSCode 확장 자동 설치 (아래 표 참고) |
+
+### 자동 설치되는 VSCode 확장
+
+| 확장 ID | 역할 |
+|---------|------|
+| `oven.bun-vscode` | Bun 런타임 지원 및 디버거. TypeScript 파일 실행·디버그, 테스트 결과 인라인 표시, 실행 중 오류 위치를 에디터에서 바로 확인 |
+| `dbaeumer.vscode-eslint` | ESLint를 VSCode에 통합. 코드 작성 중 린팅 오류를 밑줄/경고로 표시하고 Quick Fix로 자동 수정 |
+| `esbenp.prettier-vscode` | 파일 저장 시 코드 스타일 자동 정리 (들여쓰기, 따옴표, 세미콜론 등) |
+| `EditorConfig.EditorConfig` | `.editorconfig` 파일을 읽어 에디터 설정을 자동으로 적용. 팀원 간 불필요한 diff 방지 |
+
+### Codespaces를 사용하지 않는 경우
+
+로컬 환경에서 개발하는 경우 Bun을 직접 설치해야 합니다.
+
+**macOS / Linux**
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+**Windows (PowerShell)**
+```powershell
+powershell -c "irm bun.sh/install.ps1 | iex"
+```
+
+설치 확인:
+```bash
+bun --version
+```
+
+---
+
+## 주요 Bun 명령어
+
+| 명령어 | 설명 |
+|--------|------|
+| `bun install` | `package.json` 의존성 설치 |
+| `bun run <script>` | `package.json`의 스크립트 실행 |
+| `bun run <file.ts>` | TypeScript 파일 직접 실행 |
+| `bun add <package>` | 패키지 추가 |
+| `bun add -d <package>` | 개발 의존성 패키지 추가 |
+| `bun remove <package>` | 패키지 제거 |
+| `bun build <file.ts>` | 번들 빌드 |
+| `bun test` | 테스트 실행 |
+| `bun --watch run <file.ts>` | 파일 변경 감지 후 자동 재실행 |
+
+---
+
+## 권장 설정
+
+### tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+### 패키지 관리
+
+Bun은 자체 lockfile(`bun.lockb`)을 사용합니다. `package-lock.json`이나 `yarn.lock` 대신 `bun.lockb`를 커밋에 포함하세요.

--- a/docs/ts-bun-guide
+++ b/docs/ts-bun-guide
@@ -17,7 +17,6 @@ TypeScript를 직접 실행할 수 있는 런타임으로는 **Deno**와 **Bun**
     "vscode": {
       "extensions": [
         "oven.bun-vscode",
-        "ms-vscode.vscode-typescript-next",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "EditorConfig.EditorConfig"
@@ -32,7 +31,6 @@ TypeScript를 직접 실행할 수 있는 런타임으로는 **Deno**와 **Bun**
 | 확장 ID | 역할 |
 |---------|------|
 | `oven.bun-vscode` | Bun 런타임 지원 및 디버거. TypeScript 파일 실행·디버그, 테스트 결과 인라인 표시, 실행 중 오류 위치를 에디터에서 바로 확인 |
-| `ms-vscode.vscode-typescript-next` | TypeScript nightly 빌드 적용. 최신 TypeScript 기능을 안정 릴리즈 전에 사용 가능 |
 | `dbaeumer.vscode-eslint` | ESLint를 VSCode에 통합. 코드 작성 중 린팅 오류를 밑줄/경고로 표시하고 Quick Fix로 자동 수정 |
 | `esbenp.prettier-vscode` | 파일 저장 시 코드 스타일 자동 정리 (들여쓰기, 따옴표, 세미콜론 등) |
 | `EditorConfig.EditorConfig` | `.editorconfig` 파일을 읽어 에디터 설정을 자동으로 적용. 팀원 간 불필요한 diff 방지 |


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #2 

### 변경사항
- [x] `docs/ts-bun-guide.md` 추가 — TypeScript + Bun 개발환경 가이드 문서 작성

### 🧪 테스트 방법 (선택 사항)
1. Codespaces 실행 후 `.devcontainer/devcontainer.json`에 명시된 VSCode 확장 5종 자동 설치 확인
2. 터미널에서 `bun --version` 입력 후 버전 출력 확인
3. `bun run index.ts` 실행 후 정상 동작 확인

### 💬 참고 사항 (선택 사항)
- 이슈 요구사항 외에 실제 저장소 파일(`devcontainer.json`, `tsconfig.json`, `bun.lock`) 기준으로 내용을 반영했습니다.
- `docs/README.md`의 문서 목록은 별도 이슈에서 업데이트 예정입니다.
