### PR TITLE
devcontainer에서 ms-vscode.vscode-typescript-next extension 제거 (#12)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
     "vscode": {
       "extensions": [
         "oven.bun-vscode",
-        "ms-vscode.vscode-typescript-next",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
         "EditorConfig.EditorConfig"


### PR DESCRIPTION
### ISSUE_ID
Closes #12

### 변경사항
- [x] .devcontainer/devcontainer.json의 extensions 목록에서 ms-vscode.vscode-typescript-next 제거

### 🧪 테스트 방법 (선택 사항)
devcontainer 리빌드 후 `code --list-extensions` 명령어로 해당 extension이 설치되지 않음을 확인

```
$ code --list-extensions
Codespaces: curly happiness에 설치된 확장:
dbaeumer.vscode-eslint
editorconfig.editorconfig
esbenp.prettier-vscode
github.codespaces
github.github-vscode-theme
github.vscode-pull-request-github
ms-ceintl.vscode-language-pack-ko
oven.bun-vscode
```

### 💬 참고 사항 (선택 사항)
이슈 #12에서 나온대로, TypeScript 최신 nightly 빌드를 사용하는 고급 사용자를 대상으로 하므로 일반 기여자에게는 불필요하여 제거합니다.
이미 컨테이너를 빌드한 환경이라면 리빌드가 필요합니다.