### PR TITLE
doc/cac-guide.md에 참고 자료 추가

### DIFF
--- a/docs/cac-guide.md
+++ b/docs/cac-guide.md
@@ -106,3 +106,11 @@ bun run index.ts --help
 - CLI 개발 방식 통일
 - 유지보수성 향상
 - 개발자 간 협업 효율 증가
+
+---
+
+## 참고 문서
+
+- [cac GitHub Repository](https://github.com/cacjs/cac)
+- [cac npm Package](https://www.npmjs.com/package/cac)
+


### PR DESCRIPTION
### ISSUE_ID
Closes #37

### 변경사항
- docs/cac-guide.md에 참고 자료 섹션 추가
- 참고 자료로 cac GitHub 저장소 및 npm 패키지 링크 추가

### 🧪 테스트 방법 (선택 사항)
없음

### 💬 참고 사항 (선택 사항)
없음
