### PR TITLE
저장소의 이슈 및 PR 개수를 가져오는 CLI 명령어 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,59 @@
 import { graphql } from "@octokit/graphql";
 import { cac } from "cac";
 
-console.log("graphql imported:", typeof graphql);
-console.log("cac imported:", typeof cac);
+interface RepositoryStatsResponse {
+  repository: {
+    issues: {
+      totalCount: number;
+    };
+    pullRequests: {
+      totalCount: number;
+    };
+  };
+}
+
+const cli = cac("reposcore-ts");
+
+cli
+  .command("<owner> <repo>", "저장소의 이슈 수와 PR 수를 출력합니다")
+  .option(
+    "--token <token>",
+    "GitHub Personal Access Token (기본값: $GITHUB_TOKEN)",
+  )
+  .action(async (owner: string, repo: string, options: { token?: string }) => {
+    const token = options.token ?? Bun.env.GITHUB_TOKEN;
+    if (!token) {
+      console.error(
+        "오류: GitHub 토큰이 필요합니다. --token 옵션 또는 GITHUB_TOKEN 환경 변수를 설정하세요.",
+      );
+      process.exit(1);
+    }
+
+    const githubGraphQL = graphql.defaults({
+      headers: {
+        authorization: `token ${token}`,
+      },
+    });
+
+    const result = await githubGraphQL<RepositoryStatsResponse>(
+      `
+      query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          issues {
+            totalCount
+          }
+          pullRequests {
+            totalCount
+          }
+        }
+      }
+      `,
+      { owner, repo },
+    );
+
+    console.log(`이슈 수: ${result.repository.issues.totalCount}`);
+    console.log(`PR 수: ${result.repository.pullRequests.totalCount}`);
+  });
+
+cli.help();
+cli.parse();


### PR DESCRIPTION
### ISSUE_ID

Closes #47

### 변경사항
- [x] `@octokit/graphql`을 사용해 GitHub GraphQL API 클라이언트 설정 추가
- [x] `cac`를 사용해 `<owner> <repo>` 위치 인자 및 `--token` 옵션을 받는 CLI 구성
- [x] GraphQL 쿼리로 저장소의 전체 이슈 수 및 PR 수를 조회 후 출력하는 기능 구현

### 🧪 테스트 방법 (선택 사항)

```bash
GITHUB_TOKEN=your_token bun run index.ts oss2026hnu reposcore-ts
```

정상 동작 시 아래와 같이 출력됩니다:

```
이슈 수: 28
PR 수: 24
```

### 💬 참고 사항 (선택 사항)
- GitHub 토큰은 `--token <token>` 옵션 또는 `GITHUB_TOKEN` 환경 변수로 전달할 수 있습니다.
- octokit-guide.md의 인터페이스 및 쿼리 예시를 참고하여 구현했습니다.
- `RepositoryStatsResponse` 인터페이스로 GraphQL 응답 타입을 정의하였으며, `totalCount` 필드를 사용해 페이지네이션 없이 전체 개수를 조회합니다.