### PR TITLE
.gitignore의 package-json.lock 항목 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ lerna-debug.log*
 # database
 *.sqlite
 
-# package-json
-package-json.lock
-
 # bun deploy file
 node_modules.bun
 


### PR DESCRIPTION
### ISSUE_ID
Closes #71

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- .gitignore에서 # package-json 주석을 제거했습니다.
- 실제 저장소에서 사용되지 않는 package-json.lock 항목을 삭제했습니다.
- 현재 저장소에서 사용 중인 package-lock.json, bun.lock 관련 설정은 변경하지 않았습니다.

### 🧪 테스트 방법 (선택 사항)
없음

### 💬 참고 사항 (선택 사항)
없음
