### PR TITLE
GitHub Actions에 Bun CLI 기본 실행 확인 워크플로우 추가

### DIFF
--- a/.github/workflows/bun-cli-check.yml
+++ b/.github/workflows/bun-cli-check.yml
@@ -1,0 +1,18 @@
+name: Bun CLI Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  bun-cli-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install
+
+      - run: bun run index.ts --help


### PR DESCRIPTION
### ISSUE_ID
Closes #76

### 변경사항
- .github/workflows/bun-cli-check.yml 파일을 추가했습니다.
- GitHub Actions에서 Bun 설치 및 의존성 설치 후 bun run index.ts --help를 실행하도록 구성했습니다.
- PR 및 push 시 Bun 기반 CLI의 기본 실행 가능 여부를 자동으로 확인할 수 있도록 설정했습니다.

### 🧪 테스트 방법 (선택 사항)
bun install 후 bun run index.ts --help 실행하여 동작 확인
실제 GitHub API 요청은 수행하지 않고 CLI의 기본 실행 가능 여부만 확인

### 💬 참고 사항 (선택 사항)
없음
