### PR TITLE
Cac default 옵션 기반 기본값 처리로 변경

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,19 +16,21 @@ const cli = cac("reposcore-ts");
 
 cli
   .command("[...repos]", "대상 저장소 목록 (예: owner/repo1 owner/repo2)")
-  .option(
-    "--token <token>",
-    "GitHub Personal Access Token (기본값: $GITHUB_TOKEN)",
-  )
-  .option("--format <format>", "출력 형식 (csv, txt)", { default: "csv" })
+  .option("--token <token>", "GitHub Personal Access Token", {
+    default: "$GITHUB_TOKEN",
+  })
+  .option("--format <format>", "출력 형식 (csv, txt)", {
+    default: "csv",
+  })
   .action(async (repos: string[], options: { token?: string; format: string }) => {
-    // 1. 토큰 체크 (process.exit 대신 return으로 흐름 제어)
-    const token = options.token ?? Bun.env.GITHUB_TOKEN;
+    const token =
+      options.token === "$GITHUB_TOKEN" ? Bun.env.GITHUB_TOKEN : options.token;
+
     if (!token) {
       console.error(
         "오류: GitHub 토큰이 필요합니다. --token 옵션 또는 GITHUB_TOKEN 환경 변수를 설정하세요.",
       );
-      return; 
+      return;
     }
 
     // 2. 저장소 입력 여부 확인


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/74

### 변경사항
- [x] Cac의 default 옵션을 활용하도록 --token 옵션 기본값 처리 방식 수정
- [x] 수동으로 작성하던 기본값 안내 문자열 제거 및 help 자동 출력 적용

### 🧪 테스트 방법 (선택 사항)
bun start --help 
bun tsc --noEmit 
bun start oss2026hnu/reposcore-ts

### 💬 참고 사항 (선택 사항)
cac의 기본값 자동 출력 기능을 활용하면서도 실제 환경 변수 토큰 값은 노출되지 않도록 처리했습니다.