### PR TITLE
[DOC] docs/ts-convention.md 제목 번호 및 공백 정리

### DIFF
--- a/docs/ts-convention.md
+++ b/docs/ts-convention.md
@@ -5,7 +5,7 @@
 
 ---
 
-##  네이밍 규칙
+## 네이밍 규칙
 
 | 대상 | 규칙 | 예시 |
 |---|---|---|
@@ -19,7 +19,7 @@
 
 ---
 
-##  타입 정의 방식 (interface vs type)
+## 타입 정의 방식 (interface vs type)
 
 - **interface** → 객체 형태의 타입 정의에 사용
 - **type** → 유니온, 인터섹션 등 복잡한 타입 정의에 사용
@@ -59,7 +59,7 @@ const getIssues = async (repo: string): Promise<Issue[]> => {
 
 ---
 
-## 4. import/export 규칙
+## import/export 규칙
 
 - **named export** 를 기본으로 사용합니다.
 - `index.ts` 에서 모듈을 한곳에 모아 re-export 합니다.
@@ -75,7 +75,7 @@ import { calculateScore, UserScore } from './score-calculator';
 
 ---
 
-## 5. 기본 코드 스타일
+## 기본 코드 스타일
 
 - 들여쓰기: **2 spaces**
 - 세미콜론: **항상 사용**


### PR DESCRIPTION
Remove remaining manual heading numbers and extra heading spaces in docs/ts-convention.md.

### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #87

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [x] `docs/ts-convention.md`에 남아 있던 수동 제목 번호를 제거했습니다.
- [x] `## 4. import/export 규칙`을 `## import/export 규칙`으로 수정했습니다.
- [x] `## 5. 기본 코드 스타일`을 `## 기본 코드 스타일`로 수정했습니다.
- [x] `##` 뒤에 들어간 불필요한 다중 공백을 정리했습니다.

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
- GitHub Markdown Preview에서 문서 제목이 정상적으로 표시되는 것을 확인했습니다.
- 표, 목록, 코드블록이 기존과 동일하게 렌더링되는 것을 확인했습니다.
- 문서 파일만 수정했으며 코드 로직 변경은 없습니다.

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
현재 main 기준으로 `docs/ts-convention.md`의 일부 제목에 수동 번호와 불필요한 공백이 남아 있어 문서 제목 형식을 일관되게 정리했습니다.
