### PR TITLE
GitHub GraphQL 통신 모듈 분리

### DIFF
--- a/github-service.ts
+++ b/github-service.ts
@@ -1,0 +1,46 @@
+import { graphql } from "@octokit/graphql";
+
+export interface RepoStats {
+  issues: number;
+  pullRequests: number;
+}
+
+interface RepositoryStatsResponse {
+  repository: {
+    issues: {
+      totalCount: number;
+    };
+    pullRequests: {
+      totalCount: number;
+    };
+  };
+}
+
+export function createGitHubService(token: string) {
+  const githubGraphQL = graphql.defaults({
+    headers: {
+      authorization: `token ${token}`,
+    },
+  });
+
+  return {
+    async getRepoStats(owner: string, repo: string): Promise<RepoStats> {
+      const result = await githubGraphQL<RepositoryStatsResponse>(
+        `
+        query($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            issues { totalCount }
+            pullRequests { totalCount }
+          }
+        }
+        `,
+        { owner, repo },
+      );
+
+      return {
+        issues: result.repository.issues.totalCount,
+        pullRequests: result.repository.pullRequests.totalCount,
+      };
+    },
+  };
+}

--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,5 @@
-import { graphql } from "@octokit/graphql";
 import { cac } from "cac";
-
-interface RepositoryStatsResponse {
-  repository: {
-    issues: {
-      totalCount: number;
-    };
-    pullRequests: {
-      totalCount: number;
-    };
-  };
-}
+import { createGitHubService } from "./github-service";
 
 const cli = cac("reposcore-ts");
 
@@ -33,7 +22,6 @@ cli
       return;
     }
 
-    // 2. 저장소 입력 여부 확인
     if (repos.length === 0) {
       console.error("오류: 최소 하나 이상의 저장소(owner/repo)를 입력해야 합니다.");
       cli.outputHelp();
@@ -44,11 +32,7 @@ cli
     console.log(`저장소: ${repos.join(", ")}`);
     console.log(`형식: ${options.format}`);
 
-    const githubGraphQL = graphql.defaults({
-      headers: {
-        authorization: `token ${token}`,
-      },
-    });
+    const githubService = createGitHubService(token);
 
     for (const repoPath of repos) {
       if (!repoPath.includes("/")) {
@@ -56,22 +40,12 @@ cli
         continue;
       }
 
-      const [owner, repoName] = repoPath.split("/");
+      const [owner, repoName] = repoPath.split("/") as [string, string];
 
       try {
-        const result = await githubGraphQL<RepositoryStatsResponse>(
-          `
-          query($owner: String!, $repo: String!) {
-            repository(owner: $owner, name: $repo) {
-              issues { totalCount }
-              pullRequests { totalCount }
-            }
-          }
-          `,
-          { owner, repo: repoName },
-        );
+        const stats = await githubService.getRepoStats(owner, repoName);
 
-        console.log(`[${repoPath}] 이슈: ${result.repository.issues.totalCount}, PR: ${result.repository.pullRequests.totalCount}`);
+        console.log(`[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`);
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/63

### 변경사항
- [x] GitHub GraphQL 통신 로직을 github-service.ts 파일로 분리
- [x] index.ts가 CLI 입력 처리 및 결과 출력만 담당하도록 구조 정리
- [x] 저장소 통계 조회 기능을 getRepoStats(owner, repo) 메서드로 구현

### 🧪 테스트 방법 (선택 사항)
- bun run index.ts oss2026hnu/reposcore-ts
- bun run index.ts oss2026hnu/reposcore-ts --token <token>
- bun run index.ts invalidrepo
- bun run index.ts --help
- bun tsc --noEmit

위 명령어들을 실행하여 정상 출력 및 오류 처리를 확인하였습니다.

### 💬 참고 사항 (선택 사항)
