### PR TITLE
저장소 인자 형식 검증 강화

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,5 @@
-import { graphql } from "@octokit/graphql";
 import { cac } from "cac";
-
-interface RepositoryStatsResponse {
-  repository: {
-    issues: {
-      totalCount: number;
-    };
-    pullRequests: {
-      totalCount: number;
-    };
-  };
-}
+import { createGitHubService } from "./github-service";
 
 const cli = cac("reposcore-ts");
 
@@ -33,7 +22,6 @@ cli
       return;
     }
 
-    // 저장소 입력 여부 확인
     if (repos.length === 0) {
       console.error("오류: 최소 하나 이상의 저장소(owner/repo)를 입력해야 합니다.");
       cli.outputHelp();
@@ -44,11 +32,7 @@ cli
     console.log(`저장소: ${repos.join(", ")}`);
     console.log(`형식: ${options.format}`);
 
-    const githubGraphQL = graphql.defaults({
-      headers: {
-        authorization: `token ${token}`,
-      },
-    });
+    const githubService = createGitHubService(token);
 
     for (const repoPath of repos) {
       const parts = repoPath.split("/");
@@ -61,27 +45,13 @@ cli
       const [owner, repoName] = parts;
 
       try {
-        const result = await githubGraphQL<RepositoryStatsResponse>(
-          `
-          query($owner: String!, $repo: String!) {
-            repository(owner: $owner, name: $repo) {
-              issues { totalCount }
-              pullRequests { totalCount }
-            }
-          }
-          `,
-          { owner, repo: repoName },
-        );
+        const stats = await githubService.getRepoStats(owner, repoName);
 
-        console.log(
-          `[${repoPath}] 이슈: ${result.repository.issues.totalCount}, PR: ${result.repository.pullRequests.totalCount}`,
-        );
+        console.log(`[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`);
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-
         console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);
         console.error(`상세 원인: ${errorMessage}`);
-
         process.exit(1);
       }
     }

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,16 @@
+import { graphql } from "@octokit/graphql";
 import { cac } from "cac";
-import { createGitHubService } from "./github-service";
+
+interface RepositoryStatsResponse {
+  repository: {
+    issues: {
+      totalCount: number;
+    };
+    pullRequests: {
+      totalCount: number;
+    };
+  };
+}
 
 const cli = cac("reposcore-ts");
 
@@ -22,6 +33,7 @@ cli
       return;
     }
 
+    // 저장소 입력 여부 확인
     if (repos.length === 0) {
       console.error("오류: 최소 하나 이상의 저장소(owner/repo)를 입력해야 합니다.");
       cli.outputHelp();
@@ -32,24 +44,44 @@ cli
     console.log(`저장소: ${repos.join(", ")}`);
     console.log(`형식: ${options.format}`);
 
-    const githubService = createGitHubService(token);
+    const githubGraphQL = graphql.defaults({
+      headers: {
+        authorization: `token ${token}`,
+      },
+    });
 
     for (const repoPath of repos) {
-      if (!repoPath.includes("/")) {
+      const parts = repoPath.split("/");
+
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
         console.error(`오류: '${repoPath}'는 'owner/repo' 형식이 아닙니다. 건너뜀.`);
         continue;
       }
 
-      const [owner, repoName] = repoPath.split("/") as [string, string];
+      const [owner, repoName] = parts;
 
       try {
-        const stats = await githubService.getRepoStats(owner, repoName);
+        const result = await githubGraphQL<RepositoryStatsResponse>(
+          `
+          query($owner: String!, $repo: String!) {
+            repository(owner: $owner, name: $repo) {
+              issues { totalCount }
+              pullRequests { totalCount }
+            }
+          }
+          `,
+          { owner, repo: repoName },
+        );
 
-        console.log(`[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`);
+        console.log(
+          `[${repoPath}] 이슈: ${result.repository.issues.totalCount}, PR: ${result.repository.pullRequests.totalCount}`,
+        );
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
+
         console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);
         console.error(`상세 원인: ${errorMessage}`);
+
         process.exit(1);
       }
     }


### PR DESCRIPTION
### ISSUE_ID
Closes #98

### 변경사항
- 저장소 인자 검증 방식을 기존 `/` 포함 여부 검사에서 `split("/")` 기반 검사로 개선했습니다. 
- 저장소 인자가 정확히 `owner/repo` 형식인지 확인하도록 수정했습니다. 
- owner 또는 repo 이름이 비어 있는 경우 오류 메시지를 출력하고 해당 저장소를 건너뛰도록 처리했습니다.

### 🧪 테스트 방법 (선택 사항)
1. 아래 명령어들을 실행하여 잘못된 저장소 인자가 오류 메시지와 함께 건너뛰어지는지 확인했습니다. 
- bun run index.ts owner/ 
- bun run index.ts /repo 
- bun run index.ts owner/repo/extra 
- bun run index.ts invalid

2. 또한 아래 명령어를 통해 정상적인 owner/repo 형식의 저장소는 기존처럼 GraphQL 요청이 수행되는지 확인했습니다.
- bun run index.ts oss2026hnu/reposcore-ts

### 💬 참고 사항 (선택 사항)
없음
