### PR TITLE
#101 docs/octokit-guide.md 예시 저장소명 수정

### DIFF
--- a/docs/octokit-guide.md
+++ b/docs/octokit-guide.md
@@ -92,8 +92,8 @@ const result = await githubGraphQL<IssuesResponse>(
   }
   `,
   {
-    owner: "oss2025hnu",
-    repo: "reposcore-cs",
+    owner: "oss2026hnu",
+    repo: "reposcore-ts",
   }
 );
 
@@ -122,8 +122,8 @@ const result = await githubGraphQL<PullRequestsResponse>(
   }
   `,
   {
-    owner: "oss2025hnu",
-    repo: "reposcore-cs",
+    owner: "oss2026hnu",
+    repo: "reposcore-ts",
   }
 );
 
@@ -153,8 +153,8 @@ const result = await githubGraphQL(
   }
   `,
   {
-    owner: "oss2025hnu",
-    repo: "reposcore-cs",
+    owner: "oss2026hnu",
+    repo: "reposcore-ts",
   }
 );
 ```


### PR DESCRIPTION
---
**제목:** docs/octokit-guide.md 예시 저장소명 수정
---

### ISSUE_ID
Closes #101

### 변경사항
- [x] `docs/octokit-guide.md`의 Issue 조회 예시 저장소명 수정 (`oss2025hnu/reposcore-cs` → `oss2026hnu/reposcore-ts`)
- [x] `docs/octokit-guide.md`의 Pull Request 조회 예시 저장소명 수정
- [x] `docs/octokit-guide.md`의 Issue + PR 통합 조회 예시 저장소명 수정

### 🧪 테스트 방법 (선택 사항)


### 💬 참고 사항 (선택 사항)
코드 로직 변경 없이 문서 예시 저장소명만 수정한 작업입니다.