### PR TITLE
#111  저장소 조회 실패 시 즉시 종료 대신 계속 처리하도록 개선

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,8 @@ cli
 
       const githubService = createGitHubService(token);
 
+      let hasError = false;
+
       for (const repoPath of repos) {
         const parts = repoPath.split('/');
 
@@ -46,6 +48,7 @@ cli
           console.error(
             `오류: '${repoPath}'는 'owner/repo' 형식이 아닙니다. 건너뜀.`,
           );
+          hasError = true;
           continue;
         }
 
@@ -62,8 +65,12 @@ cli
             error instanceof Error ? error.message : String(error);
           console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);
           console.error(`상세 원인: ${errorMessage}`);
-          process.exit(1);
+          hasError = true;
         }
+      }
+
+      if (hasError) {
+        process.exitCode = 1;
       }
     },
   );


### PR DESCRIPTION
### ISSUE_ID
Closes #111

### 변경사항

- [x] `index.ts` catch 블록에서 `process.exit(1)` 제거
- [x] 저장소 조회 실패 시 `hasError = true`로 기록 후 다음 저장소 계속 처리
- [x] 루프 종료 후 `hasError`가 true이면 `process.exitCode = 1` 설정

### 🧪 테스트 방법

**케이스 1: 첫 번째 저장소 실패, 두 번째 성공**
```bash
bun run index.ts owner/invalid-repo oss2026hnu/reposcore-ts; echo "exit code: $?"
```
기대 결과: `owner/invalid-repo` 오류 출력 후 `oss2026hnu/reposcore-ts` 정상 조회, exit code 1

**케이스 2: 전체 성공**
```bash
bun run index.ts oss2026hnu/reposcore-ts; echo "exit code: $?"
```
기대 결과: 정상 조회, exit code 0

**케이스 3: 형식 오류 + 정상 저장소 혼합**
```bash
bun run index.ts invalid-format oss2026hnu/reposcore-ts
```
기대 결과: `invalid-format` 건너뜀, `oss2026hnu/reposcore-ts` 정상 조회

### 💬 참고 사항

`github-service.ts` 및 GraphQL 쿼리 구조는 변경하지 않았습니다.