### PR TITLE
[DOC] 최상위 README 내용 최적화 및 다중 저장소 처리 안내 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,6 @@ Install dependencies:
 bun install
 ```
 
-Run the CLI:
-
-```bash
-bun run index.ts <owner/repo> [options]
-```
-
-Example:
-
-```bash
-bun run index.ts oss2026hnu/reposcore-ts --format csv
-```
-
-You can also pass a GitHub Personal Access Token with `--token`:
-
-```bash
-bun run index.ts oss2026hnu/reposcore-ts --token your_token --format txt
-```
-
 If you do not pass a token with `--token`, set the `GITHUB_TOKEN` environment variable before running the CLI.
 
 ## Synopsis
@@ -35,6 +17,12 @@ If you do not pass a token with `--token`, set the `GITHUB_TOKEN` environment va
 ```text
 For more info, run any command with the `--help` flag:
   $ reposcore-ts --help
+
+Usage:
+  $ reposcore-ts [...repos]
+
+여러 개의 저장소를 한 번에 분석할 수 있습니다.
+  예: reposcore-ts owner/repo1 owner/repo2 owner/repo3
 
 Options:
   --token <token>    GitHub Personal Access Token (default: $GITHUB_TOKEN)


### PR DESCRIPTION
### ISSUE_ID
Closes #115

### 변경사항
- [x] Synopsis와 중복되던 `Run the CLI` / `Example` / 토큰 사용 예시 블록 제거
- [x] Synopsis에 실제 CLI 시그니처 `[...repos]` 반영
- [x] 다중 저장소 인자(`owner/repo1 owner/repo2 ...`) 지원 안내 추가

### 🧪 테스트 방법 (선택 사항)
- README.md 렌더링 결과를 확인하여 Synopsis와 본문 사이의 중복이 사라졌는지 점검
- `bun run index.ts --help` 출력과 README의 Synopsis 옵션 항목이 일치하는지 비교

### 💬 참고 사항 (선택 사항)
- 코드/CLI 동작 변경 없이 문서만 수정한 PR입니다.
- `GITHUB_TOKEN` 환경 변수 안내는 동작 설명이라 그대로 유지했습니다.
