### PR TITLE
[FIX] 인자/옵션 형식 오류 처리 방식 개선

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,21 @@ import {createGitHubService} from './github-service';
 
 const cli = cac('reposcore-ts');
 
+const supportedFormats = ['csv', 'txt'];
+
+function parseRepoPath(repoPath: string) {
+  const parts = repoPath.split('/');
+
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+
+  return {
+    owner: parts[0],
+    repoName: parts[1],
+  };
+}
+
 cli
   .command('[...repos]', '대상 저장소 목록 (예: owner/repo1 owner/repo2)')
   .option('--token <token>', 'GitHub Personal Access Token', {
@@ -15,42 +30,65 @@ cli
     async (repos: string[], options: {token?: string; format: string}) => {
       const token =
         options.token === '$GITHUB_TOKEN'
-          ? Bun.env.GITHUB_TOKEN
-          : options.token;
+          ? Bun.env.GITHUB_TOKEN || ''
+          : options.token || '';
+      const format = String(options.format || '').toLowerCase();
+      const errors: string[] = [];
+      const parsedRepos: {
+        repoPath: string;
+        owner: string;
+        repoName: string;
+      }[] = [];
 
       if (!token) {
-        console.error(
+        errors.push(
           '오류: GitHub 토큰이 필요합니다. --token 옵션 또는 GITHUB_TOKEN 환경 변수를 설정하세요.',
         );
-        return;
+      }
+
+      if (!supportedFormats.includes(format)) {
+        errors.push(
+          `오류: 지원하지 않는 출력 형식 '${options.format}'입니다. csv 또는 txt를 입력하세요.`,
+        );
       }
 
       if (repos.length === 0) {
-        console.error(
+        errors.push(
           '오류: 최소 하나 이상의 저장소(owner/repo)를 입력해야 합니다.',
         );
+      }
+
+      for (const repoPath of repos) {
+        const parsedRepo = parseRepoPath(repoPath);
+
+        if (!parsedRepo) {
+          errors.push(`오류: '${repoPath}'는 'owner/repo' 형식이 아닙니다.`);
+          continue;
+        }
+
+        parsedRepos.push({
+          repoPath,
+          owner: parsedRepo.owner,
+          repoName: parsedRepo.repoName,
+        });
+      }
+
+      if (errors.length > 0) {
+        for (const error of errors) {
+          console.error(error);
+        }
+
         cli.outputHelp();
-        return;
+        process.exit(1);
       }
 
       console.log('분석 기능 구현 중입니다.');
       console.log(`저장소: ${repos.join(', ')}`);
-      console.log(`형식: ${options.format}`);
+      console.log(`형식: ${format}`);
 
       const githubService = createGitHubService(token);
 
-      for (const repoPath of repos) {
-        const parts = repoPath.split('/');
-
-        if (parts.length !== 2 || !parts[0] || !parts[1]) {
-          console.error(
-            `오류: '${repoPath}'는 'owner/repo' 형식이 아닙니다. 건너뜀.`,
-          );
-          continue;
-        }
-
-        const [owner, repoName] = parts;
-
+      for (const {repoPath, owner, repoName} of parsedRepos) {
         try {
           const stats = await githubService.getRepoStats(owner, repoName);
 
@@ -60,6 +98,7 @@ cli
         } catch (error: unknown) {
           const errorMessage =
             error instanceof Error ? error.message : String(error);
+
           console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);
           console.error(`상세 원인: ${errorMessage}`);
           process.exit(1);


### PR DESCRIPTION
### ISSUE_ID
Closes #117

### 변경사항
- [x] CLI 인자/옵션 형식 오류를 먼저 검사하도록 정리했습니다.
- [x] 오류가 여러 개 있는 경우 오류 메시지를 누적해서 출력하도록 수정했습니다.
- [x] 오류 메시지를 모두 출력한 뒤 `cli.outputHelp()`가 한 번만 실행되도록 수정했습니다.
- [x] 형식 오류가 있는 경우 `process.exit(1)`로 비정상 종료되도록 수정했습니다.
- [x] 지원하지 않는 `--format` 값에 대한 검증을 추가했습니다.
- [x] 기존 `createGitHubService(token)` 및 `getRepoStats(owner, repoName)` 호출 방식은 유지했습니다.

### 🧪 테스트 방법
- `bun run lint`
- `bun run index.ts wrong-repo --format xml --token dummy`
- `echo $?`
- `env -u GITHUB_TOKEN bun run index.ts`
- `echo $?`
- `bun run index.ts --help`

### 💬 참고 사항
- 이번 PR은 `index.ts`의 CLI 인자/옵션 검증 흐름만 수정합니다.
- 기존 CLI 구조와 `github-service.ts`의 `getRepoStats` 호출 방식은 유지했습니다.
- GitHub GraphQL 쿼리, 점수 계산 로직, README/docs 문서는 수정하지 않았습니다.
- 실제 GitHub 조회 실패 시 즉시 `process.exit(1)`로 종료하는 기존 동작은 유지했습니다.