### PR TITLE
[DOC] docs/README.md 공통 내용 참고 가이드 구체화

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # 프로젝트 운영 지침 및 개발 가이드
 
-> 점수 계산 공식 및 이슈/PR 작성 주의사항 등 공통 사항은
+> 점수 계산 공식, 이슈/PR 작성 주의사항, 도커 및 깃헙 사용법처럼
+> `reposcore-cs`와 공통으로 적용되는 내용은
 > [reposcore-cs 저장소](https://github.com/oss2026hnu/reposcore-cs)의 docs를 참고하세요.
 
 ## 문서 목록


### PR DESCRIPTION
### ISSUE_ID
Closes #114

### 변경사항
- [x] `docs/README.md` 상단의 공통 문서 참고 안내를 더 구체적으로 정리했습니다.
- [x] 점수 계산 공식, 이슈/PR 작성 주의사항, 도커 및 깃헙 사용법이 `reposcore-cs`와 공통으로 적용되는 항목임을 명시했습니다.
- [x] 기존 `reposcore-cs` docs 참고 링크는 유지했습니다.
- [x] 문서 목록과 자동 갱신 안내는 수정하지 않았습니다.

### 테스트 방법
- GitHub에서 `docs/README.md` 미리보기를 확인했습니다.
- 변경 파일이 `docs/README.md` 1개인지 확인했습니다.

### 참고 사항
- 이번 PR은 기존 안내 문구를 중복 추가하지 않고, #114에서 요구한 공통 항목이 더 명확히 보이도록 기존 안내문을 보강한 문서 수정입니다.