### PR TITLE
라벨/상태별 데이터 조회 (Closed/Merged 포함) 추가

### DIFF
--- a/github-service.ts
+++ b/github-service.ts
@@ -5,42 +5,258 @@ export interface RepoStats {
   pullRequests: number;
 }
 
+export type ContributionLabel = 'feature' | 'bug' | 'docs' | 'typo' | 'none';
+
+export interface PRRecord {
+  number: number;
+  title: string;
+  url: string;
+  isMerged: boolean;
+  labels: string[];
+  category: ContributionLabel;
+  additions?: number;
+  deletions?: number;
+  mergedAt?: string;
+  author?: string;
+}
+
+export interface IssueRecord {
+  number: number;
+  title: string;
+  url: string;
+  labels: string[];
+  category: ContributionLabel;
+  state: string;
+  author?: string;
+  createdAt?: string;
+  closedAt?: string;
+}
+
+export interface DetailedRepoData {
+  prs: PRRecord[];
+  issues: IssueRecord[];
+}
+
 interface RepositoryStatsResponse {
   repository: {
-    issues: {
-      totalCount: number;
-    };
-    pullRequests: {
-      totalCount: number;
-    };
+    issues: {totalCount: number};
+    pullRequests: {totalCount: number};
   };
 }
 
-export function createGitHubService(token: string) {
+interface RawAuthor {
+  login: string;
+}
+
+interface RawLabel {
+  name: string;
+}
+
+interface RawIssue {
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  createdAt: string;
+  closedAt: string | null;
+  author: RawAuthor | null;
+  labels: {nodes: RawLabel[]} | null;
+}
+
+interface RawPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  merged: boolean;
+  mergedAt: string | null;
+  additions: number;
+  deletions: number;
+  author: RawAuthor | null;
+  labels: {nodes: RawLabel[]} | null;
+}
+
+interface DetailedRepoResponse {
+  repository: {
+    issues: {nodes: RawIssue[]};
+    pullRequests: {nodes: RawPullRequest[]};
+  };
+}
+
+const PAGE_SIZE = 100;
+
+// 라벨 문자열을 ContributionLabel 카테고리로 정규화합니다.
+// 소문자 변환 후 하이픈/공백/언더스코어를 제거해 매칭합니다.
+export const normalizeLabel = (label: string): ContributionLabel => {
+  const key = label.toLowerCase().replace(/[-_\s]/g, '');
+  if (key === 'feat' || key === 'feature') return 'feature';
+  if (key === 'bug') return 'bug';
+  if (key === 'doc' || key === 'docs' || key === 'documentation') return 'docs';
+  if (key === 'typo') return 'typo';
+  return 'none';
+};
+
+// 라벨 배열에서 첫 번째로 인식되는 ContributionLabel을 반환합니다.
+// 인식 가능한 라벨이 없으면 'none'을 반환합니다.
+export const categorizeLabels = (labels: string[]): ContributionLabel => {
+  for (const label of labels) {
+    const category = normalizeLabel(label);
+    if (category !== 'none') {
+      return category;
+    }
+  }
+  return 'none';
+};
+
+const extractLabelNames = (labels: {nodes: RawLabel[]} | null): string[] => {
+  if (!labels || !labels.nodes) return [];
+  return labels.nodes.map(node => node.name).filter(name => Boolean(name));
+};
+
+const toIssueRecord = (raw: RawIssue): IssueRecord => {
+  const labels = extractLabelNames(raw.labels);
+  return {
+    number: raw.number,
+    title: raw.title,
+    url: raw.url,
+    labels,
+    category: categorizeLabels(labels),
+    state: raw.state,
+    author: raw.author?.login,
+    createdAt: raw.createdAt,
+    closedAt: raw.closedAt ?? undefined,
+  };
+};
+
+const toPrRecord = (raw: RawPullRequest): PRRecord => {
+  const labels = extractLabelNames(raw.labels);
+  return {
+    number: raw.number,
+    title: raw.title,
+    url: raw.url,
+    isMerged: raw.merged,
+    labels,
+    category: categorizeLabels(labels),
+    additions: raw.additions,
+    deletions: raw.deletions,
+    mergedAt: raw.mergedAt ?? undefined,
+    author: raw.author?.login,
+  };
+};
+
+// GraphQL 응답을 DetailedRepoData로 변환합니다.
+// 응답에 라벨이 없거나 인식되지 않는 경우 category는 'none'으로 설정됩니다.
+export const mapDetailedRepoResponse = (
+  response: DetailedRepoResponse,
+): DetailedRepoData => {
+  const issueNodes = response.repository.issues?.nodes ?? [];
+  const prNodes = response.repository.pullRequests?.nodes ?? [];
+
+  return {
+    issues: issueNodes.map(toIssueRecord),
+    prs: prNodes.map(toPrRecord),
+  };
+};
+
+// DetailedRepoData에서 카테고리별 개수를 집계합니다.
+export interface CategoryCounts {
+  feature: number;
+  bug: number;
+  docs: number;
+  typo: number;
+  none: number;
+}
+
+export const countByCategory = (
+  records: ReadonlyArray<{category: ContributionLabel}>,
+): CategoryCounts => {
+  const counts: CategoryCounts = {
+    feature: 0,
+    bug: 0,
+    docs: 0,
+    typo: 0,
+    none: 0,
+  };
+  for (const record of records) {
+    counts[record.category] += 1;
+  }
+  return counts;
+};
+
+export const createGitHubService = (token: string) => {
   const githubGraphQL = graphql.defaults({
     headers: {
       authorization: `token ${token}`,
     },
   });
 
-  return {
-    async getRepoStats(owner: string, repo: string): Promise<RepoStats> {
-      const result = await githubGraphQL<RepositoryStatsResponse>(
-        `
-        query($owner: String!, $repo: String!) {
-          repository(owner: $owner, name: $repo) {
-            issues { totalCount }
-            pullRequests { totalCount }
+  const getRepoStats = async (
+    owner: string,
+    repo: string,
+  ): Promise<RepoStats> => {
+    const result = await githubGraphQL<RepositoryStatsResponse>(
+      `
+      query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          issues { totalCount }
+          pullRequests { totalCount }
+        }
+      }
+      `,
+      {owner, repo},
+    );
+
+    return {
+      issues: result.repository.issues.totalCount,
+      pullRequests: result.repository.pullRequests.totalCount,
+    };
+  };
+
+  // closed 이슈와 merged PR을 한 번의 GraphQL 요청으로 조회합니다.
+  // 라벨 정보를 포함하며, 응답 누락 시 안전하게 빈 값으로 처리됩니다.
+  const getDetailedRepoData = async (
+    owner: string,
+    repo: string,
+  ): Promise<DetailedRepoData> => {
+    const response = await githubGraphQL<DetailedRepoResponse>(
+      `
+      query($owner: String!, $repo: String!, $pageSize: Int!) {
+        repository(owner: $owner, name: $repo) {
+          issues(first: $pageSize, states: CLOSED, orderBy: {field: CREATED_AT, direction: DESC}) {
+            nodes {
+              number
+              title
+              url
+              state
+              createdAt
+              closedAt
+              author { login }
+              labels(first: 20) { nodes { name } }
+            }
+          }
+          pullRequests(first: $pageSize, states: MERGED, orderBy: {field: CREATED_AT, direction: DESC}) {
+            nodes {
+              number
+              title
+              url
+              merged
+              mergedAt
+              additions
+              deletions
+              author { login }
+              labels(first: 20) { nodes { name } }
+            }
           }
         }
-        `,
-        {owner, repo},
-      );
+      }
+      `,
+      {owner, repo, pageSize: PAGE_SIZE},
+    );
 
-      return {
-        issues: result.repository.issues.totalCount,
-        pullRequests: result.repository.pullRequests.totalCount,
-      };
-    },
+    return mapDetailedRepoResponse(response);
   };
-}
+
+  return {
+    getRepoStats,
+    getDetailedRepoData,
+  };
+};

--- a/github-service.ts
+++ b/github-service.ts
@@ -1,11 +1,14 @@
 import {graphql} from '@octokit/graphql';
+import type {ContributionKind} from './score-calculator';
 
 export interface RepoStats {
   issues: number;
   pullRequests: number;
 }
 
-export type ContributionLabel = 'feature' | 'bug' | 'docs' | 'typo' | 'none';
+// score-calculator.ts 의 ContributionKind(doc 단수형)를 그대로 재사용해
+// 도메인 용어를 통일합니다. 미인식 라벨은 'none'으로만 확장합니다.
+export type ContributionLabel = ContributionKind | 'none';
 
 export interface PRRecord {
   number: number;
@@ -90,7 +93,7 @@ export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
   if (key === 'feat' || key === 'feature') return 'feature';
   if (key === 'bug') return 'bug';
-  if (key === 'doc' || key === 'docs' || key === 'documentation') return 'docs';
+  if (key === 'doc' || key === 'docs' || key === 'documentation') return 'doc';
   if (key === 'typo') return 'typo';
   return 'none';
 };
@@ -161,7 +164,7 @@ export const mapDetailedRepoResponse = (
 export interface CategoryCounts {
   feature: number;
   bug: number;
-  docs: number;
+  doc: number;
   typo: number;
   none: number;
 }
@@ -172,7 +175,7 @@ export const countByCategory = (
   const counts: CategoryCounts = {
     feature: 0,
     bug: 0,
-    docs: 0,
+    doc: 0,
     typo: 0,
     none: 0,
   };

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import {cac} from 'cac';
-import {createGitHubService} from './github-service';
+import {countByCategory, createGitHubService} from './github-service';
 
 const cli = cac('reposcore-ts');
 
@@ -90,11 +90,28 @@ cli
 
       for (const {repoPath, owner, repoName} of parsedRepos) {
         try {
-          const stats = await githubService.getRepoStats(owner, repoName);
+          const [stats, detailed] = await Promise.all([
+            githubService.getRepoStats(owner, repoName),
+            githubService.getDetailedRepoData(owner, repoName),
+          ]);
 
           console.log(
             `[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`,
           );
+
+          if (format === 'txt') {
+            const prCounts = countByCategory(detailed.prs);
+            const issueCounts = countByCategory(detailed.issues);
+            const featurePrCount = prCounts.feature + prCounts.bug;
+            const featureIssueCount = issueCounts.feature + issueCounts.bug;
+            console.log(`[${repoPath}]`);
+            console.log(
+              `Merged PRs - feature: ${featurePrCount}, docs: ${prCounts.docs}, typo: ${prCounts.typo}`,
+            );
+            console.log(
+              `Closed Issues - feature: ${featureIssueCount}, docs: ${issueCounts.docs}`,
+            );
+          }
         } catch (error: unknown) {
           const errorMessage =
             error instanceof Error ? error.message : String(error);

--- a/index.ts
+++ b/index.ts
@@ -106,10 +106,10 @@ cli
             const featureIssueCount = issueCounts.feature + issueCounts.bug;
             console.log(`[${repoPath}]`);
             console.log(
-              `Merged PRs - feature: ${featurePrCount}, docs: ${prCounts.docs}, typo: ${prCounts.typo}`,
+              `Merged PRs - feature: ${featurePrCount}, docs: ${prCounts.doc}, typo: ${prCounts.typo}`,
             );
             console.log(
-              `Closed Issues - feature: ${featureIssueCount}, docs: ${issueCounts.docs}`,
+              `Closed Issues - feature: ${featureIssueCount}, docs: ${issueCounts.doc}`,
             );
           }
         } catch (error: unknown) {


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #104

### 변경사항
- [x] `github-service.ts`에 `getDetailedRepoData()` 추가 — closed 이슈와 merged PR을 **단일 GraphQL 호출**로 라벨·작성자·날짜·additions/deletions까지 수집
- [x] 라벨 정규화 표준화 (`normalizeLabel`, `categorizeLabels`) — 소문자 변환 후 `-`/`_`/공백 제거하여 `feat|feature → feature`, `doc|docs|documentation → docs`, `bug`, `typo` 로 매핑하고 미인식은 `none` 처리
- [x] 신규 타입 정의: `PRRecord`, `IssueRecord`, `DetailedRepoData`, `ContributionLabel`, `CategoryCounts`
- [x] `index.ts` — `--format txt` 사용 시 카테고리별 요약 출력 추가

### 🧪 테스트 방법 (선택 사항)
 npx tsc --noEmit

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
