### PR TITLE
feat: GitHub API 응답 로컬 캐싱 및 --no-cache 옵션 추가

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -1,0 +1,60 @@
+const CACHE_DIR = '.cache';
+
+// 저장소별 분석 캐시 데이터 구조. JSON 파일로 직렬화되어 저장됨.
+export interface RepoCache<T> {
+  repository: string;
+  lastAnalyzedAt: string; // ISO 8601
+  data: T;
+}
+
+// 캐시 파일 경로를 반환합니다.
+const getCacheFilePath = (owner: string, repo: string): string =>
+  `${CACHE_DIR}/${owner}_${repo}/cache.json`;
+
+// 기존 캐시 파일을 읽어 RepoCache 객체를 반환합니다.
+// 파일이 없거나 손상된 경우, 또는 noCache=true이면 null을 반환합니다.
+export const loadCache = async <T>(
+  owner: string,
+  repo: string,
+  noCache = false,
+): Promise<RepoCache<T> | null> => {
+  if (noCache) {
+    console.error('캐시를 무시하고 전체 데이터를 다시 수집합니다.');
+    return null;
+  }
+
+  const cacheFile = getCacheFilePath(owner, repo);
+  const file = Bun.file(cacheFile);
+
+  if (!(await file.exists())) return null;
+
+  try {
+    const cache = (await file.json()) as RepoCache<T>;
+    if (cache.repository !== `${owner}/${repo}`) return null;
+
+    console.error(`[cache] ${owner}/${repo} — 캐시에서 읽습니다.`);
+    return cache;
+  } catch {
+    console.error('기존 캐시 파일이 손상되어 새로 수집을 시작합니다.');
+    return null;
+  }
+};
+
+// 분석 결과 캐시를 JSON 파일로 저장. 저장 시각을 함께 기록합니다.
+export const saveCache = async <T>(
+  owner: string,
+  repo: string,
+  data: T,
+): Promise<void> => {
+  const cache: RepoCache<T> = {
+    repository: `${owner}/${repo}`,
+    lastAnalyzedAt: new Date().toISOString(),
+    data,
+  };
+
+  await Bun.write(
+    getCacheFilePath(owner, repo),
+    JSON.stringify(cache, null, 2),
+  );
+  console.error(`[cache] ${owner}/${repo} — 캐시를 저장했습니다.`);
+};

--- a/github-service.ts
+++ b/github-service.ts
@@ -1,4 +1,5 @@
 import {graphql} from '@octokit/graphql';
+import {loadCache, saveCache} from './cache';
 import type {ContributionKind} from './score-calculator';
 
 export interface RepoStats {
@@ -216,10 +217,16 @@ export const createGitHubService = (token: string) => {
 
   // closed 이슈와 merged PR을 한 번의 GraphQL 요청으로 조회합니다.
   // 라벨 정보를 포함하며, 응답 누락 시 안전하게 빈 값으로 처리됩니다.
+  // useCache=true(기본)이면 .cache/<owner>_<repo>.json을 읽어 재사용하고,
+  // 캐시가 없거나 useCache=false이면 API를 호출한 뒤 결과를 저장합니다.
   const getDetailedRepoData = async (
     owner: string,
     repo: string,
+    useCache = true,
   ): Promise<DetailedRepoData> => {
+    const cached = await loadCache<DetailedRepoData>(owner, repo, !useCache);
+    if (cached) return cached.data;
+
     const response = await githubGraphQL<DetailedRepoResponse>(
       `
       query($owner: String!, $repo: String!, $pageSize: Int!) {
@@ -255,7 +262,11 @@ export const createGitHubService = (token: string) => {
       {owner, repo, pageSize: PAGE_SIZE},
     );
 
-    return mapDetailedRepoResponse(response);
+    const data = mapDetailedRepoResponse(response);
+
+    await saveCache(owner, repo, data);
+
+    return data;
   };
 
   return {

--- a/index.ts
+++ b/index.ts
@@ -26,13 +26,18 @@ cli
   .option('--format <format>', '출력 형식 (csv, txt)', {
     default: 'csv',
   })
+  .option('--no-cache', '캐시를 무시하고 GitHub API를 새로 호출합니다')
   .action(
-    async (repos: string[], options: {token?: string; format: string}) => {
+    async (
+      repos: string[],
+      options: {token?: string; format: string; cache: boolean},
+    ) => {
       const token =
         options.token === '$GITHUB_TOKEN'
           ? Bun.env.GITHUB_TOKEN || ''
           : options.token || '';
       const format = String(options.format || '').toLowerCase();
+      const useCache = options.cache; // --no-cache 전달 시 false
       const errors: string[] = [];
       const parsedRepos: {
         repoPath: string;
@@ -92,7 +97,7 @@ cli
         try {
           const [stats, detailed] = await Promise.all([
             githubService.getRepoStats(owner, repoName),
-            githubService.getDetailedRepoData(owner, repoName),
+            githubService.getDetailedRepoData(owner, repoName, useCache),
           ]);
 
           console.log(


### PR DESCRIPTION
### ISSUE_ID
Closes #134

### 변경사항
- [x] `cache.ts` 신규 추가 — `RepoCache<T>` 인터페이스, `loadCache<T>()`, `saveCache<T>()` 구현 (Bun 내장 API 사용으로 async), 캐시 경로: `.cache/<owner>_<repo>/cache.json`
- [x] `github-service.ts` — `getDetailedRepoData()`에 `useCache` 파라미터 추가, `loadCache`/`saveCache` 연결
- [x] `index.ts` — `--no-cache` CLI 옵션 추가

### 🧪 테스트 방법 (선택 사항)
```bash
# 첫 실행 — API 호출 후 캐시 저장
bun run index.ts oss2026hnu/reposcore-ts
# [cache] oss2026hnu/reposcore-ts — 캐시를 저장했습니다.

# 두 번째 실행 — 캐시에서 읽기
bun run index.ts oss2026hnu/reposcore-ts
# [cache] oss2026hnu/reposcore-ts — 캐시에서 읽습니다.

# --no-cache 옵션
bun run index.ts oss2026hnu/reposcore-ts --no-cache
# ℹ️  캐시를 무시하고 전체 데이터를 다시 수집합니다.
```

### 💬 참고 사항 (선택 사항)
- 캐시 TTL 정책은 이슈 범위 밖으로, `--no-cache`를 통한 수동 갱신만 지원합니다.
- `.cache/`는 `.gitignore`에 이미 등록되어 있어 캐시 파일은 커밋되지 않습니다.
- `node:fs` 대신 Bun 내장 API(`Bun.file`, `Bun.write`)를 사용하여 `async`로 구현했습니다.
- 이슈에서 `github-service.ts` 내부 연결 지점만 명시했으나, 재사용성과 cs 레포와의 구조 일관성을 위해 캐시 로직을 `cache.ts`로 분리했습니다.