### PR TITLE
[FEAT] 점수 산정 파이프라인 CLI 연결 및 기본 CSV 출력 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ bun install
 
 ### CLI 실행
 
-여러 개의 저장소를 한 번에 분석할 수 있습니다.
+여러 개의 저장소를 한 번에 분석할 수 있습니다. 기본 실행 시 사용자별 점수가 CSV로 stdout에 출력됩니다(헤더: `userId,prFeatureBug,prDocs,prTypo,issueFeatureBug,issueDocs,totalScore`).
 
 ```bash
 # 기본 실행 예시

--- a/github-service.ts
+++ b/github-service.ts
@@ -1,43 +1,14 @@
 import {graphql} from '@octokit/graphql';
-import type {ContributionKind} from './score-calculator';
+import type {
+  ContributionLabel,
+  DetailedRepoData,
+  IssueRecord,
+  PRRecord,
+} from './types';
 
 export interface RepoStats {
   issues: number;
   pullRequests: number;
-}
-
-// score-calculator.ts 의 ContributionKind(doc 단수형)를 그대로 재사용해
-// 도메인 용어를 통일합니다. 미인식 라벨은 'none'으로만 확장합니다.
-export type ContributionLabel = ContributionKind | 'none';
-
-export interface PRRecord {
-  number: number;
-  title: string;
-  url: string;
-  isMerged: boolean;
-  labels: string[];
-  category: ContributionLabel;
-  additions?: number;
-  deletions?: number;
-  mergedAt?: string;
-  author?: string;
-}
-
-export interface IssueRecord {
-  number: number;
-  title: string;
-  url: string;
-  labels: string[];
-  category: ContributionLabel;
-  state: string;
-  author?: string;
-  createdAt?: string;
-  closedAt?: string;
-}
-
-export interface DetailedRepoData {
-  prs: PRRecord[];
-  issues: IssueRecord[];
 }
 
 interface RepositoryStatsResponse {

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import {cac} from 'cac';
 import {countByCategory, createGitHubService} from './github-service';
+import {ScoreCalculator, type RepoData} from './score-calculator';
 
 const cli = cac('reposcore-ts');
 
@@ -82,11 +83,8 @@ cli
         process.exit(1);
       }
 
-      console.log('분석 기능 구현 중입니다.');
-      console.log(`저장소: ${repos.join(', ')}`);
-      console.log(`형식: ${format}`);
-
       const githubService = createGitHubService(token);
+      const repoDataList: RepoData[] = [];
 
       for (const {repoPath, owner, repoName} of parsedRepos) {
         try {
@@ -97,6 +95,10 @@ cli
 
           console.log(
             `[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`,
+          );
+
+          repoDataList.push(
+            ScoreCalculator.calculateRepoData(detailed, owner, repoName),
           );
 
           if (format === 'txt') {
@@ -119,6 +121,32 @@ cli
           console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);
           console.error(`상세 원인: ${errorMessage}`);
           process.exit(1);
+        }
+      }
+
+      if (format === 'csv') {
+        const userScores = ScoreCalculator.calculateUserScores(repoDataList);
+        console.log(
+          'userId,prFeatureBug,prDocs,prTypo,issueFeatureBug,issueDocs,totalScore',
+        );
+        for (const user of userScores) {
+          let prFeatureBug = 0;
+          let prDocs = 0;
+          let prTypo = 0;
+          let issueFeatureBug = 0;
+          let issueDocs = 0;
+          for (const repo of user.repoScores) {
+            for (const data of repo.scoreData) {
+              prFeatureBug += data.prFeatureBug;
+              prDocs += data.prDocs;
+              prTypo += data.prTypo;
+              issueFeatureBug += data.issueFeatureBug;
+              issueDocs += data.issueDocs;
+            }
+          }
+          console.log(
+            `${user.userId},${prFeatureBug},${prDocs},${prTypo},${issueFeatureBug},${issueDocs},${user.totalScore}`,
+          );
         }
       }
     },

--- a/score-calculator.ts
+++ b/score-calculator.ts
@@ -1,27 +1,4 @@
-export type ContributionKind = 'feature' | 'bug' | 'doc' | 'typo';
-
-export interface IssueInfo {
-  userId: string;
-  kind: ContributionKind;
-  isClosed: boolean;
-  title: string;
-  url: string;
-}
-
-export interface PrInfo {
-  userId: string;
-  kind: ContributionKind;
-  isMerged: boolean;
-  title: string;
-  url: string;
-}
-
-export interface RepoStats {
-  owner: string;
-  repo: string;
-  issues: IssueInfo[];
-  pullRequests: PrInfo[];
-}
+import type {DetailedRepoData} from './types';
 
 export interface IssuePrData {
   userId: string;
@@ -52,7 +29,9 @@ export class ScoreCalculator {
   private static readonly ISSUE_DOCS_WEIGHT = 1;
 
   // 저장소의 이슈와 PR을 사용자별 IssuePrData 리스트로 변환합니다.
-  static buildIssuePrData(repoStats: RepoStats): IssuePrData[] {
+  // category === 'none'(미인식 라벨)인 항목은 점수 산정 대상이 아니므로 건너뜁니다.
+  // author가 없는 경우(삭제된 사용자/봇)는 'unknown'으로 매핑합니다.
+  static buildIssuePrData(repo: DetailedRepoData): IssuePrData[] {
     const bucket = new Map<string, IssuePrData>();
 
     const getOrCreate = (userId: string): IssuePrData => {
@@ -73,22 +52,24 @@ export class ScoreCalculator {
       return created;
     };
 
-    for (const issue of repoStats.issues) {
-      const target = getOrCreate(issue.userId);
-      if (issue.kind === 'feature' || issue.kind === 'bug') {
+    for (const issue of repo.issues) {
+      if (issue.category === 'none') continue;
+      const target = getOrCreate(issue.author ?? 'unknown');
+      if (issue.category === 'feature' || issue.category === 'bug') {
         target.issueFeatureBug += 1;
-      } else if (issue.kind === 'doc') {
+      } else if (issue.category === 'doc') {
         target.issueDocs += 1;
       }
     }
 
-    for (const pr of repoStats.pullRequests) {
-      const target = getOrCreate(pr.userId);
-      if (pr.kind === 'feature' || pr.kind === 'bug') {
+    for (const pr of repo.prs) {
+      if (pr.category === 'none') continue;
+      const target = getOrCreate(pr.author ?? 'unknown');
+      if (pr.category === 'feature' || pr.category === 'bug') {
         target.prFeatureBug += 1;
-      } else if (pr.kind === 'doc') {
+      } else if (pr.category === 'doc') {
         target.prDocs += 1;
-      } else if (pr.kind === 'typo') {
+      } else if (pr.category === 'typo') {
         target.prTypo += 1;
       }
     }
@@ -96,12 +77,16 @@ export class ScoreCalculator {
     return Array.from(bucket.values());
   }
 
-  // RepoStats를 RepoData로 변환하여 저장소별 scoreData를 만듭니다.
-  static calculateRepoData(repoStats: RepoStats): RepoData {
+  // DetailedRepoData를 RepoData로 변환하여 저장소별 scoreData를 만듭니다.
+  static calculateRepoData(
+    detailed: DetailedRepoData,
+    owner: string,
+    repo: string,
+  ): RepoData {
     return {
-      owner: repoStats.owner,
-      repo: repoStats.repo,
-      scoreData: ScoreCalculator.buildIssuePrData(repoStats),
+      owner,
+      repo,
+      scoreData: ScoreCalculator.buildIssuePrData(detailed),
     };
   }
 

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,38 @@
+// reposcore-ts 도메인 공용 타입.
+// github-service.ts(데이터 생산)와 score-calculator.ts(점수 계산)가
+// 동일한 shape을 직접 공유하기 위해 한 곳에 모읍니다.
+
+export type ContributionKind = 'feature' | 'bug' | 'doc' | 'typo';
+
+// 인식되지 않는 라벨은 'none'으로 표현합니다.
+export type ContributionLabel = ContributionKind | 'none';
+
+export interface PRRecord {
+  number: number;
+  title: string;
+  url: string;
+  isMerged: boolean;
+  labels: string[];
+  category: ContributionLabel;
+  additions?: number;
+  deletions?: number;
+  mergedAt?: string;
+  author?: string;
+}
+
+export interface IssueRecord {
+  number: number;
+  title: string;
+  url: string;
+  labels: string[];
+  category: ContributionLabel;
+  state: string;
+  author?: string;
+  createdAt?: string;
+  closedAt?: string;
+}
+
+export interface DetailedRepoData {
+  prs: PRRecord[];
+  issues: IssueRecord[];
+}


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #136

### 변경사항
- [x] types.ts 신설: 같은 데이터 타입를 한번에 관리하는 것이 좋으므로 : 도메인 공용 타입을 한 곳으로 모음.
- [x] score-calculator: 기존 IssueInfo/PrInfo/RepoStats 제거, buildIssuePrData/calculateRepoData가 DetailedRepoData를 직접 입력으로 받음. category === 'none' 항목 스킵, author 없으면 'unknown'으로 매핑.
- [x] github-service: 임의 로컬 타입 정의 제거 후 types.ts에서 import.
- [x] index.ts: placeholder 3줄 제거, calculateRepoData 누적 → calculateUserScores → stdout CSV 출력 (userId,prFeatureBug,prDocs,prTypo,issueFeatureBug,issueDocs,totalScore). txt 분기와 [repoPath] 요약 줄은 기존 동작 유지.
- [x] README: 기본 실행 시 CSV stdout 출력 동작 한 줄 보강.


### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
