### PR TITLE
[FEAT] --format 옵션에 따른 결과 파일 저장 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ bun-debug.log*
 
 # 실수로 npm 같은 거 돌려서 나오는 파일 무시
 package-lock.json
+
+# CLI 분석 결과 출력 디렉토리
+output/

--- a/github-service.ts
+++ b/github-service.ts
@@ -2,11 +2,6 @@ import {graphql} from '@octokit/graphql';
 import {loadCache, saveCache} from './cache';
 import type {ContributionKind} from './score-calculator';
 
-export interface RepoStats {
-  issues: number;
-  pullRequests: number;
-}
-
 // score-calculator.ts 의 ContributionKind(doc 단수형)를 그대로 재사용해
 // 도메인 용어를 통일합니다. 미인식 라벨은 'none'으로만 확장합니다.
 export type ContributionLabel = ContributionKind | 'none';
@@ -39,13 +34,6 @@ export interface IssueRecord {
 export interface DetailedRepoData {
   prs: PRRecord[];
   issues: IssueRecord[];
-}
-
-interface RepositoryStatsResponse {
-  repository: {
-    issues: {totalCount: number};
-    pullRequests: {totalCount: number};
-  };
 }
 
 interface RawAuthor {
@@ -193,28 +181,6 @@ export const createGitHubService = (token: string) => {
     },
   });
 
-  const getRepoStats = async (
-    owner: string,
-    repo: string,
-  ): Promise<RepoStats> => {
-    const result = await githubGraphQL<RepositoryStatsResponse>(
-      `
-      query($owner: String!, $repo: String!) {
-        repository(owner: $owner, name: $repo) {
-          issues { totalCount }
-          pullRequests { totalCount }
-        }
-      }
-      `,
-      {owner, repo},
-    );
-
-    return {
-      issues: result.repository.issues.totalCount,
-      pullRequests: result.repository.pullRequests.totalCount,
-    };
-  };
-
   // closed 이슈와 merged PR을 한 번의 GraphQL 요청으로 조회합니다.
   // 라벨 정보를 포함하며, 응답 누락 시 안전하게 빈 값으로 처리됩니다.
   // useCache=true(기본)이면 .cache/<owner>_<repo>.json을 읽어 재사용하고,
@@ -270,7 +236,6 @@ export const createGitHubService = (token: string) => {
   };
 
   return {
-    getRepoStats,
     getDetailedRepoData,
   };
 };

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,13 @@
 import {cac} from 'cac';
-import {countByCategory, createGitHubService} from './github-service';
+import {createGitHubService} from './github-service';
+import type {DetailedRepoData} from './github-service';
+import {summarizeRepo, writeOutputFiles} from './output';
+import type {RepoSummary} from './output';
 
 const cli = cac('reposcore-ts');
 
-const supportedFormats = ['csv', 'txt'];
+const supportedFormats = ['csv', 'txt'] as const;
+type SupportedFormat = (typeof supportedFormats)[number];
 
 function parseRepoPath(repoPath: string) {
   const parts = repoPath.split('/');
@@ -51,7 +55,7 @@ cli
         );
       }
 
-      if (!supportedFormats.includes(format)) {
+      if (!supportedFormats.includes(format as SupportedFormat)) {
         errors.push(
           `오류: 지원하지 않는 출력 형식 '${options.format}'입니다. csv 또는 txt를 입력하세요.`,
         );
@@ -87,36 +91,17 @@ cli
         process.exit(1);
       }
 
-      console.log('분석 기능 구현 중입니다.');
-      console.log(`저장소: ${repos.join(', ')}`);
-      console.log(`형식: ${format}`);
+      console.error(`형식: ${format}`);
+      console.error(`저장소: ${repos.join(', ')}`);
 
       const githubService = createGitHubService(token);
+      const summaries: RepoSummary[] = [];
 
       for (const {repoPath, owner, repoName} of parsedRepos) {
         try {
-          const [stats, detailed] = await Promise.all([
-            githubService.getRepoStats(owner, repoName),
-            githubService.getDetailedRepoData(owner, repoName, useCache),
-          ]);
-
-          console.log(
-            `[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`,
-          );
-
-          if (format === 'txt') {
-            const prCounts = countByCategory(detailed.prs);
-            const issueCounts = countByCategory(detailed.issues);
-            const featurePrCount = prCounts.feature + prCounts.bug;
-            const featureIssueCount = issueCounts.feature + issueCounts.bug;
-            console.log(`[${repoPath}]`);
-            console.log(
-              `Merged PRs - feature: ${featurePrCount}, docs: ${prCounts.doc}, typo: ${prCounts.typo}`,
-            );
-            console.log(
-              `Closed Issues - feature: ${featureIssueCount}, docs: ${issueCounts.doc}`,
-            );
-          }
+          const detailed: DetailedRepoData =
+            await githubService.getDetailedRepoData(owner, repoName, useCache);
+          summaries.push(summarizeRepo(repoPath, detailed));
         } catch (error: unknown) {
           const errorMessage =
             error instanceof Error ? error.message : String(error);
@@ -125,6 +110,12 @@ cli
           console.error(`상세 원인: ${errorMessage}`);
           process.exit(1);
         }
+      }
+
+      const written = await writeOutputFiles(format as SupportedFormat, summaries);
+      console.error(`CSV 저장: ${written.csv}`);
+      if ('txt' in written) {
+        console.error(`TXT 저장: ${written.txt}`);
       }
     },
   );

--- a/output.ts
+++ b/output.ts
@@ -1,0 +1,99 @@
+import {countByCategory} from './github-service';
+import type {DetailedRepoData} from './github-service';
+
+const DEFAULT_OUTPUT_DIR = 'output';
+const CSV_FILENAME = 'scores.csv';
+const TXT_FILENAME = 'scores.txt';
+
+export interface RepoSummary {
+  repoPath: string;
+  mergedPrFeatureBug: number;
+  mergedPrDocs: number;
+  mergedPrTypo: number;
+  closedIssueFeatureBug: number;
+  closedIssueDocs: number;
+}
+
+export interface OutputPaths {
+  csv: string;
+  txt: string;
+}
+
+// 향후 --output 옵션이 추가되어도 경로 조합 로직이 한곳에 모이도록 분리합니다.
+export const getOutputPaths = (
+  outputDir: string = DEFAULT_OUTPUT_DIR,
+): OutputPaths => ({
+  csv: `${outputDir}/${CSV_FILENAME}`,
+  txt: `${outputDir}/${TXT_FILENAME}`,
+});
+
+// DetailedRepoData를 저장소별 요약(RepoSummary)으로 변환합니다.
+// CSV/TXT 양쪽 모두 이 단일 구조에서 직접 생성합니다.
+export const summarizeRepo = (
+  repoPath: string,
+  detailed: DetailedRepoData,
+): RepoSummary => {
+  const prCounts = countByCategory(detailed.prs);
+  const issueCounts = countByCategory(detailed.issues);
+  return {
+    repoPath,
+    mergedPrFeatureBug: prCounts.feature + prCounts.bug,
+    mergedPrDocs: prCounts.doc,
+    mergedPrTypo: prCounts.typo,
+    closedIssueFeatureBug: issueCounts.feature + issueCounts.bug,
+    closedIssueDocs: issueCounts.doc,
+  };
+};
+
+const CSV_HEADERS = [
+  'repository',
+  'mergedPrFeatureBug',
+  'mergedPrDocs',
+  'mergedPrTypo',
+  'closedIssueFeatureBug',
+  'closedIssueDocs',
+] as const;
+
+export const buildCsvText = (summaries: ReadonlyArray<RepoSummary>): string => {
+  const rows = summaries.map(s =>
+    [
+      s.repoPath,
+      s.mergedPrFeatureBug,
+      s.mergedPrDocs,
+      s.mergedPrTypo,
+      s.closedIssueFeatureBug,
+      s.closedIssueDocs,
+    ].join(','),
+  );
+  return [CSV_HEADERS.join(','), ...rows].join('\n') + '\n';
+};
+
+export const buildTxtText = (summaries: ReadonlyArray<RepoSummary>): string => {
+  const blocks = summaries.map(s =>
+    [
+      `[${s.repoPath}]`,
+      `Merged PRs - feature: ${s.mergedPrFeatureBug}, docs: ${s.mergedPrDocs}, typo: ${s.mergedPrTypo}`,
+      `Closed Issues - feature: ${s.closedIssueFeatureBug}, docs: ${s.closedIssueDocs}`,
+    ].join('\n'),
+  );
+  return blocks.join('\n\n') + '\n';
+};
+
+// CSV는 항상 생성, format이 'txt'인 경우 TXT를 추가로 생성합니다.
+// reposcore-cs와 동일한 사양을 따릅니다.
+export const writeOutputFiles = async (
+  format: 'csv' | 'txt',
+  summaries: ReadonlyArray<RepoSummary>,
+  outputDir: string = DEFAULT_OUTPUT_DIR,
+): Promise<OutputPaths | {csv: string}> => {
+  const paths = getOutputPaths(outputDir);
+
+  await Bun.write(paths.csv, buildCsvText(summaries));
+
+  if (format === 'txt') {
+    await Bun.write(paths.txt, buildTxtText(summaries));
+    return paths;
+  }
+
+  return {csv: paths.csv};
+};


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #129

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [x] `types.ts` 신설: `github-service`와 `score-calculator`가 공유하는 도메인 타입(`PRRecord`, `IssueRecord`, `DetailedRepoData`, `ContributionKind`, `ContributionLabel`)을 한 곳으로 통일
- [x] `score-calculator.ts` 리팩터링: 기존 `IssueInfo` / `PrInfo` / `RepoStats` 제거, `DetailedRepoData`를 직접 입력으로 받도록 변경, `category === 'none'` 스킵 및 `author` 부재 시 `'unknown'`으로 매핑, `UserScore.aggregated` 노출
- [x] `index.ts`: placeholder 안내 3줄 제거, 저장소 루프에서 `ScoreCalculator.calculateRepoData` 누적 → `ScoreCalculator.calculateUserScores` 호출 → 기본 실행 시 stdout에 CSV(`userId,prFeatureBug,prDocs,prTypo,issueFeatureBug,issueDocs,totalScore`) 출력 추가
- [x] `github-service.ts`: 로컬에 있던 `PRRecord` / `IssueRecord` / `ContributionLabel` / `DetailedRepoData` 정의를 제거하고 `types.ts`에서 import, `getDetailedRepoData`가 `owner` / `repo`를 포함해 반환
- [x] `README.md`: 기본 실행 시 CSV가 stdout으로 출력된다는 안내 한 줄 보강

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
1. `bun install`
2. `bun run typecheck` 통과 확인
3. `bun run lint` 통과 확인
4. 토큰을 준비해 다음 명령을 실행, CSV 헤더와 사용자별 행이 stdout으로 출력되는지 확인:
   ```bash
   bun run index.ts oss2026hnu/reposcore-ts --token YOUR_GITHUB_TOKEN
   ```
   기대 헤더:
   ```
   userId,prFeatureBug,prDocs,prTypo,issueFeatureBug,issueDocs,totalScore
   ```
5. 토큰 누락 / 잘못된 `--format` / 잘못된 `owner/repo` 형식 입력 시 기존과 동일하게 에러 일괄 출력 후 `process.exit(1)`로 종료되는지(그리고 placeholder 3줄은 더 이상 출력되지 않는지) 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
- closed #138 의 관리자 코멘트("어댑터로 변환하기보다 가능하면 양쪽 파일에서 같은 데이터 타입을 통일해서 사용하는 것이 가장 좋다")에 따라, 어댑터 함수를 추가하지 않고 도메인 공용 타입을 `types.ts`로 분리하는 방향으로 구현했습니다.
- 본 PR은 "점수 산정 파이프라인이 동작하게 만드는" 최소 변경에 집중했습니다. 단일 저장소 입력 기준 동작을 우선 보장하며, 아래 항목은 후속 이슈/PR로 분리 예정입니다:
  - 점수 내림차순 정렬
  - `./results/results.csv` 파일 저장
  - `--format txt`에 사용자별 점수 추가
  - 다중 저장소 합산 결과의 검증/UX
- `score-calculator`의 `UserScore`에 `aggregated: IssuePrData` 필드를 추가했습니다. `calculateUserScores` 내부에서 이미 reduce로 계산되던 값이라 추가 비용은 없으며, CLI에서 동일 집계 로직을 중복으로 작성하지 않기 위함입니다.
