### PR TITLE
getRepoStats 제거 및 상세 데이터 파이프라인 통합

### DIFF
--- a/github-service.ts
+++ b/github-service.ts
@@ -9,18 +9,6 @@ import type {
 
 import {loadCache, saveCache} from './cache';
 
-export interface RepoStats {
-  issues: number;
-  pullRequests: number;
-}
-
-interface RepositoryStatsResponse {
-  repository: {
-    issues: {totalCount: number};
-    pullRequests: {totalCount: number};
-  };
-}
-
 interface RawAuthor {
   login: string;
 }
@@ -61,8 +49,6 @@ interface DetailedRepoResponse {
 
 const PAGE_SIZE = 100;
 
-// 라벨 문자열을 ContributionLabel 카테고리로 정규화합니다.
-// 소문자 변환 후 하이픈/공백/언더스코어를 제거해 매칭합니다.
 export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
   if (key === 'feat' || key === 'feature') return 'feature';
@@ -72,8 +58,6 @@ export const normalizeLabel = (label: string): ContributionLabel => {
   return 'none';
 };
 
-// 라벨 배열에서 첫 번째로 인식되는 ContributionLabel을 반환합니다.
-// 인식 가능한 라벨이 없으면 'none'을 반환합니다.
 export const categorizeLabels = (labels: string[]): ContributionLabel => {
   for (const label of labels) {
     const category = normalizeLabel(label);
@@ -120,8 +104,6 @@ const toPrRecord = (raw: RawPullRequest): PRRecord => {
   };
 };
 
-// GraphQL 응답을 DetailedRepoData로 변환합니다.
-// 응답에 라벨이 없거나 인식되지 않는 경우 category는 'none'으로 설정됩니다.
 export const mapDetailedRepoResponse = (
   response: DetailedRepoResponse,
 ): DetailedRepoData => {
@@ -134,7 +116,6 @@ export const mapDetailedRepoResponse = (
   };
 };
 
-// DetailedRepoData에서 카테고리별 개수를 집계합니다.
 export interface CategoryCounts {
   feature: number;
   bug: number;
@@ -153,9 +134,11 @@ export const countByCategory = (
     typo: 0,
     none: 0,
   };
+
   for (const record of records) {
     counts[record.category] += 1;
   }
+
   return counts;
 };
 
@@ -166,32 +149,6 @@ export const createGitHubService = (token: string) => {
     },
   });
 
-  const getRepoStats = async (
-    owner: string,
-    repo: string,
-  ): Promise<RepoStats> => {
-    const result = await githubGraphQL<RepositoryStatsResponse>(
-      `
-      query($owner: String!, $repo: String!) {
-        repository(owner: $owner, name: $repo) {
-          issues { totalCount }
-          pullRequests { totalCount }
-        }
-      }
-      `,
-      {owner, repo},
-    );
-
-    return {
-      issues: result.repository.issues.totalCount,
-      pullRequests: result.repository.pullRequests.totalCount,
-    };
-  };
-
-  // closed 이슈와 merged PR을 한 번의 GraphQL 요청으로 조회합니다.
-  // 라벨 정보를 포함하며, 응답 누락 시 안전하게 빈 값으로 처리됩니다.
-  // useCache=true(기본)이면 .cache/<owner>_<repo>.json을 읽어 재사용하고,
-  // 캐시가 없거나 useCache=false이면 API를 호출한 뒤 결과를 저장합니다.
   const getDetailedRepoData = async (
     owner: string,
     repo: string,
@@ -243,7 +200,6 @@ export const createGitHubService = (token: string) => {
   };
 
   return {
-    getRepoStats,
     getDetailedRepoData,
   };
 };

--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,7 @@ cli
           ? Bun.env.GITHUB_TOKEN || ''
           : options.token || '';
       const format = String(options.format || '').toLowerCase();
-      const useCache = options.cache; // --no-cache 전달 시 false
+      const useCache = options.cache;
       const errors: string[] = [];
       const parsedRepos: {
         repoPath: string;
@@ -93,13 +93,10 @@ cli
 
       for (const {repoPath, owner, repoName} of parsedRepos) {
         try {
-          const [stats, detailed] = await Promise.all([
-            githubService.getRepoStats(owner, repoName),
-            githubService.getDetailedRepoData(owner, repoName, useCache),
-          ]);
-
-          console.log(
-            `[${repoPath}] 이슈: ${stats.issues}, PR: ${stats.pullRequests}`,
+          const detailed = await githubService.getDetailedRepoData(
+            owner,
+            repoName,
+            useCache,
           );
 
           repoDataList.push(
@@ -111,6 +108,7 @@ cli
             const issueCounts = countByCategory(detailed.issues);
             const featurePrCount = prCounts.feature + prCounts.bug;
             const featureIssueCount = issueCounts.feature + issueCounts.bug;
+
             console.log(`[${repoPath}]`);
             console.log(
               `Merged PRs - feature: ${featurePrCount}, docs: ${prCounts.doc}, typo: ${prCounts.typo}`,
@@ -131,15 +129,18 @@ cli
 
       if (format === 'csv') {
         const userScores = ScoreCalculator.calculateUserScores(repoDataList);
+
         console.log(
           'userId,prFeatureBug,prDocs,prTypo,issueFeatureBug,issueDocs,totalScore',
         );
+
         for (const user of userScores) {
           let prFeatureBug = 0;
           let prDocs = 0;
           let prTypo = 0;
           let issueFeatureBug = 0;
           let issueDocs = 0;
+
           for (const repo of user.repoScores) {
             for (const data of repo.scoreData) {
               prFeatureBug += data.prFeatureBug;
@@ -149,6 +150,7 @@ cli
               issueDocs += data.issueDocs;
             }
           }
+
           console.log(
             `${user.userId},${prFeatureBug},${prDocs},${prTypo},${issueFeatureBug},${issueDocs},${user.totalScore}`,
           );


### PR DESCRIPTION
### ISSUE_ID
Closes #140

### 변경사항
- `getRepoStats`, `RepoStats`, `RepositoryStatsResponse` 및 `totalCount` 기반 GraphQL 쿼리를 제거했습니다.
- `index.ts`에서 `getRepoStats()`와 `getDetailedRepoData()`의 이중 호출 구조를 제거하고 `getDetailedRepoData()` 단일 호출로 통합했습니다.
- 상세 데이터 기반(`author.login` 포함)의 데이터 수집 흐름만 사용하도록 정리하고 레거시 수집 레이어를 제거했습니다.

### 🧪 테스트 방법 (선택 사항)
아래 명령들을 통해 정상 동작을 확인하였습니다.
1. grep -rn "getRepoStats\|RepoStats\|RepositoryStatsResponse\|issues { totalCount }\|pullRequests { totalCount }\|분석 기능 구현 중입니다" .
2. bun run index.ts oss2026hnu/reposcore-ts --format txt --no-cache
3. bun run index.ts oss2026hnu/reposcore-ts --format csv --no-cache

### 💬 참고 사항 (선택 사항)
없음