### PR TITLE
cache.ts에 기본 캐시 유효 시간 상수 추가

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -1,5 +1,8 @@
 const CACHE_DIR = '.cache';
 
+/** 기본 캐시 유효 시간: 24시간 (밀리초 단위) */
+const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
 // 저장소별 분석 캐시 데이터 구조. JSON 파일로 직렬화되어 저장됨.
 export interface RepoCache<T> {
   repository: string;
@@ -12,7 +15,7 @@ const getCacheFilePath = (owner: string, repo: string): string =>
   `${CACHE_DIR}/${owner}_${repo}/cache.json`;
 
 // 기존 캐시 파일을 읽어 RepoCache 객체를 반환합니다.
-// 파일이 없거나 손상된 경우, 또는 noCache=true이면 null을 반환합니다.
+// 파일이 없거나 손상된 경우, noCache=true이거나 캐시가 만료된 경우 null을 반환합니다.
 export const loadCache = async <T>(
   owner: string,
   repo: string,
@@ -31,6 +34,31 @@ export const loadCache = async <T>(
   try {
     const cache = (await file.json()) as RepoCache<T>;
     if (cache.repository !== `${owner}/${repo}`) return null;
+
+    // lastAnalyzedAt 유효성 검사
+    if (!cache.lastAnalyzedAt) {
+      console.error(
+        `[cache] ${owner}/${repo} — 캐시 저장 시각이 없어 새로 수집합니다.`,
+      );
+      return null;
+    }
+
+    const analyzedAt = Date.parse(cache.lastAnalyzedAt);
+
+    if (Number.isNaN(analyzedAt)) {
+      console.error(
+        `[cache] ${owner}/${repo} — 캐시 저장 시각이 올바르지 않아 새로 수집합니다.`,
+      );
+      return null;
+    }
+
+    // TTL 초과 여부 검사
+    if (Date.now() - analyzedAt > DEFAULT_CACHE_TTL_MS) {
+      console.error(
+        `[cache] ${owner}/${repo} — 캐시가 만료되어 새로 수집합니다.`,
+      );
+      return null;
+    }
 
     console.error(`[cache] ${owner}/${repo} — 캐시에서 읽습니다.`);
     return cache;


### PR DESCRIPTION
Add default cache TTL and improve cache loading logic.

### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #151 

### 변경사항
- [x] `cache.ts`에 기본 캐시 유효 시간 상수 추가 (`DEFAULT_CACHE_TTL_MS = 24h`)
- [x] `loadCache()`에서 `lastAnalyzedAt` 존재 여부 및 날짜 유효성 검사 추가
- [x] TTL 초과 시 캐시를 사용하지 않고 `null` 반환하도록 처리
- [x] 캐시 만료 시 stderr로 안내 로그 출력
- [x] 기존 `--no-cache` 동작 유지

### 🧪 테스트 방법
```bash
# 정상 캐시 재사용 확인
bun run index.ts <owner/repo>
# 두 번째 실행 시 "캐시에서 읽습니다" 로그 확인

# 만료 확인 (캐시 파일의 lastAnalyzedAt을 25시간 전으로 직접 수정 후 실행)
bun run index.ts <owner/repo>
# "캐시가 만료되어 새로 수집합니다" 로그 확인

# 타입 검사
bun run typecheck
```
