### PR TITLE
결과 저장 방식 개선 – 저장소별 디렉토리 구조

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -105,10 +105,28 @@ cli
             repoName,
             useCache,
           );
-          repoDataList.push(
-            ScoreCalculator.calculateRepoData(detailed, owner, repoName),
+
+          const repoData = ScoreCalculator.calculateRepoData(detailed, owner, repoName);
+          const repoSummary = summarizeRepo(repoPath, detailed);
+
+          repoDataList.push(repoData);
+          repoSummaries.push(repoSummary);
+
+          const singleUserScores = ScoreCalculator.calculateUserScores([repoData]);
+          const subDir = `${owner}-${repoName}`;
+          const written = await writeOutputFiles(
+            format as SupportedFormat,
+            {
+              userScores: singleUserScores,
+              repoSummaries: [repoSummary],
+            },
+            'output',
+            subDir,
           );
-          repoSummaries.push(summarizeRepo(repoPath, detailed));
+          console.error(`[${repoPath}] CSV 저장: ${written.csv}`);
+          if ('txt' in written) {
+            console.error(`[${repoPath}] TXT 저장: ${written.txt}`);
+          }
         } catch (error: unknown) {
           const errorMessage =
             error instanceof Error ? error.message : String(error);
@@ -119,15 +137,17 @@ cli
         }
       }
 
-      const userScores = ScoreCalculator.calculateUserScores(repoDataList);
+      if (parsedRepos.length >= 2) {
+        const userScores = ScoreCalculator.calculateUserScores(repoDataList);
 
-      const written = await writeOutputFiles(format as SupportedFormat, {
-        userScores,
-        repoSummaries,
-      });
-      console.error(`CSV 저장: ${written.csv}`);
-      if ('txt' in written) {
-        console.error(`TXT 저장: ${written.txt}`);
+        const written = await writeOutputFiles(format as SupportedFormat, {
+          userScores,
+          repoSummaries,
+        });
+        console.error(`[합산] CSV 저장: ${written.csv}`);
+        if ('txt' in written) {
+          console.error(`[합산] TXT 저장: ${written.txt}`);
+        }
       }
     },
   );

--- a/output.ts
+++ b/output.ts
@@ -1,3 +1,4 @@
+import {mkdir} from 'node:fs/promises';
 import {countByCategory} from './github-service';
 import type {DetailedRepoData} from './types';
 import type {UserScore} from './score-calculator';
@@ -23,10 +24,14 @@ export interface OutputPaths {
 // 향후 --output 옵션이 추가되어도 경로 조합 로직이 한곳에 모이도록 분리합니다.
 export const getOutputPaths = (
   outputDir: string = DEFAULT_OUTPUT_DIR,
-): OutputPaths => ({
-  csv: `${outputDir}/${CSV_FILENAME}`,
-  txt: `${outputDir}/${TXT_FILENAME}`,
-});
+  subDir?: string,
+): OutputPaths => {
+  const targetDir = subDir ? `${outputDir}/${subDir}` : outputDir;
+  return {
+    csv: `${targetDir}/${CSV_FILENAME}`,
+    txt: `${targetDir}/${TXT_FILENAME}`,
+  };
+};
 
 // DetailedRepoData를 저장소별 카테고리 요약(RepoSummary)으로 변환합니다.
 // TXT 파일에서 가독성 있는 저장소별 블록을 생성하는 데 사용됩니다.
@@ -135,8 +140,12 @@ export const writeOutputFiles = async (
   format: 'csv' | 'txt',
   data: ScoreOutputData,
   outputDir: string = DEFAULT_OUTPUT_DIR,
+  subDir?: string,
 ): Promise<OutputPaths | {csv: string}> => {
-  const paths = getOutputPaths(outputDir);
+  const paths = getOutputPaths(outputDir, subDir);
+
+  const targetDir = subDir ? `${outputDir}/${subDir}` : outputDir;
+  await mkdir(targetDir, {recursive: true});
 
   await Bun.write(paths.csv, buildUserScoresCsv(data.userScores));
 


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #166 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 저장소별로 디렉토리를 구분하여 결과를 저장하는 로직 추가

### 🧪 테스트 방법 (선택 사항)
bun run index.ts oss2026hnu/reposcore-ts oss2026hnu/reposcore-cs --token {토큰}

위 명령어를 실행하여 결과 저장 폴더가 output 디렉토리 하위에 저장소별로 생기는지 확인

### 💬 참고 사항 (선택 사항)

