### PR TITLE
cache.ts 주요 함수 및 인터페이스에 TSDoc 주석 추가

### DIFF
--- a/cache.ts
+++ b/cache.ts
@@ -1,18 +1,50 @@
 const CACHE_DIR = '.cache';
 
-// 저장소별 분석 캐시 데이터 구조. JSON 파일로 직렬화되어 저장됨.
+/**
+ * 저장소별 분석 캐시 데이터 구조. JSON 파일로 직렬화되어 저장됩니다.
+ *
+ * @template T 캐시에 저장되는 실제 데이터의 타입
+ */
 export interface RepoCache<T> {
+  /** `owner/repo` 형식의 저장소 식별자. */
   repository: string;
+  /** 마지막으로 분석을 수행한 시각 (ISO 8601 형식). */
   lastAnalyzedAt: string; // ISO 8601
+  /** 캐시된 분석 결과 데이터. */
   data: T;
 }
 
-// 캐시 파일 경로를 반환합니다.
+/**
+ * 저장소 소유자와 이름을 기반으로 캐시 파일의 경로를 반환합니다.
+ *
+ * @param owner 저장소 소유자 ID 혹은 조직명
+ * @param repo 저장소 이름
+ * @returns `.cache/<owner>_<repo>/cache.json` 형식의 파일 경로 문자열
+ */
 const getCacheFilePath = (owner: string, repo: string): string =>
   `${CACHE_DIR}/${owner}_${repo}/cache.json`;
 
-// 기존 캐시 파일을 읽어 RepoCache 객체를 반환합니다.
-// 파일이 없거나 손상된 경우, 또는 noCache=true이면 null을 반환합니다.
+/**
+ * 기존 캐시 파일을 읽어 {@link RepoCache} 객체를 반환합니다.
+ *
+ * 다음의 경우 `null`을 반환합니다:
+ * - `noCache`가 `true`인 경우
+ * - 캐시 파일이 존재하지 않는 경우
+ * - 캐시 파일이 손상되었거나 파싱에 실패한 경우
+ * - 캐시 파일에 기록된 저장소 식별자가 `owner/repo`와 일치하지 않는 경우
+ *
+ * @template T 캐시에 저장된 실제 데이터의 타입
+ * @param owner 저장소 소유자 ID 혹은 조직명
+ * @param repo 저장소 이름
+ * @param noCache `true`이면 캐시를 무시하고 즉시 `null`을 반환합니다 (기본값: `false`)
+ * @returns 유효한 캐시가 있으면 {@link RepoCache} 객체, 없으면 `null`
+ *
+ * @example
+ * const cache = await loadCache<DetailedRepoData>('oss2026hnu', 'reposcore-ts');
+ * if (cache) {
+ *   console.log('캐시 히트:', cache.lastAnalyzedAt);
+ * }
+ */
 export const loadCache = async <T>(
   owner: string,
   repo: string,
@@ -40,7 +72,21 @@ export const loadCache = async <T>(
   }
 };
 
-// 분석 결과 캐시를 JSON 파일로 저장. 저장 시각을 함께 기록합니다.
+/**
+ * 분석 결과를 {@link RepoCache} 형식으로 JSON 파일에 저장합니다.
+ *
+ * 저장 시각(`lastAnalyzedAt`)은 호출 시점의 현재 시각으로 자동 기록됩니다.
+ * 대상 디렉터리가 없는 경우 Bun이 자동으로 생성합니다.
+ *
+ * @template T 캐시에 저장할 실제 데이터의 타입
+ * @param owner 저장소 소유자 ID 혹은 조직명
+ * @param repo 저장소 이름
+ * @param data 저장할 분석 결과 데이터
+ * @returns 저장 완료 후 resolve되는 `Promise<void>`
+ *
+ * @example
+ * await saveCache('oss2026hnu', 'reposcore-ts', detailedRepoData);
+ */
 export const saveCache = async <T>(
   owner: string,
   repo: string,


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #178 

### 변경사항
- [x] `RepoCache<T>` 인터페이스에 `@template`, 프로퍼티별 인라인 설명 추가
- [x] `getCacheFilePath()`에 `@param`, `@returns` 추가
- [x] `loadCache<T>()`에 `@template`, `@param`, `@returns`, `@example`, null 반환 조건 목록 추가
- [x] `saveCache<T>()`에 `@template`, `@param`, `@returns`, `@example` 추가

### 💬 참고 사항 (선택 사항)
코드 로직 변경 없이 TSDoc 주석만 추가하였습니다.
