### PR TITLE
style: fix prettier formatting violations in index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,13 @@
-import { cac } from "cac";
-import pkg from "./package.json" assert { type: "json"};
+import {cac} from 'cac';
+import pkg from './package.json' assert {type: 'json'};
 
 import {createGitHubService} from './github-service';
 import {ScoreCalculator, type RepoData} from './score-calculator';
 import {summarizeRepo, writeOutputFiles} from './output';
 import type {RepoSummary} from './output';
 
-const cli = cac("reposcore-ts");
+const cli = cac('reposcore-ts');
 cli.version(pkg.version);
-
-
-
-
 
 const supportedFormats = ['csv', 'txt'] as const;
 type SupportedFormat = (typeof supportedFormats)[number];
@@ -113,13 +109,19 @@ cli
             useCache,
           );
 
-          const repoData = ScoreCalculator.calculateRepoData(detailed, owner, repoName);
+          const repoData = ScoreCalculator.calculateRepoData(
+            detailed,
+            owner,
+            repoName,
+          );
           const repoSummary = summarizeRepo(repoPath, detailed);
 
           repoDataList.push(repoData);
           repoSummaries.push(repoSummary);
 
-          const singleUserScores = ScoreCalculator.calculateUserScores([repoData]);
+          const singleUserScores = ScoreCalculator.calculateUserScores([
+            repoData,
+          ]);
           const subDir = `${owner}-${repoName}`;
           const written = await writeOutputFiles(
             format as SupportedFormat,


### PR DESCRIPTION
Closes #173

### 변경사항
- [x] `index.ts` — prettier 포맷 위반 2건 수정 (함수 인수 줄바꿈)

> `github-service.ts` 9건은 PR #180 (e6d7740)에서 TSDoc 주석 추가 작업 중 함께 수정되어 이미 반영된 상태입니다.

### 🧪 테스트 방법
```bash
bun run fix
bun run lint
```
`bun run lint` 실행 시 오류 0건 확인

### 💬 참고 사항
로직 변경 없이 포맷만 수정. 기존 기능 삭제 및 동작 변경 없음.