### PR TITLE
docs: fix test file path example in ts-bun-guide

### DIFF
--- a/docs/ts-bun-guide.md
+++ b/docs/ts-bun-guide.md
@@ -88,7 +88,7 @@ Bun 내장 테스트 러너를 사용합니다. Jest와 호환되는 API(`descri
 bun test
 
 # 특정 파일만 실행
-bun test src/github-service.test.ts
+bun test tests/score-calculator.test.ts
 ```
 
 Bun이 자동으로 감지하는 테스트 파일 규칙:


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #184 

### 변경사항
- [x] `docs/ts-bun-guide.md` "테스트 실행" 섹션의 특정 파일 실행 예시를 실제 존재하는 경로로 수정

```diff
-bun test src/github-service.test.ts
+bun test tests/score-calculator.test.ts
```

### 🧪 테스트 방법 (선택 사항)
```bash
bun test tests/score-calculator.test.ts
```
터미널에서 위 명령이 정상 실행(테스트 통과)되는지 확인합니다.

### 💬 참고 사항 (선택 사항)
- `src/` 디렉토리는 존재하지 않으므로 예시가 잘못된 경로를 안내하고 있었습니다.