### PR TITLE
 점수 계산 버그 해결

### DIFF
--- a/github-service.ts
+++ b/github-service.ts
@@ -162,7 +162,7 @@ export const createGitHubService = (token: string) => {
 
       // 'not planned'와 'duplicate' 사유로 닫힌 이슈를 필터링합니다.
       const validNodes = connection.nodes.filter(
-        node => node.stateReason !== 'NOT_PLANNED' && node.stateReason !== 'DUPLICATE'
+        node => node.stateReason === 'COMPLETED'
       );
 
       issues.push(...validNodes.map(toIssueRecord));

--- a/github-service.ts
+++ b/github-service.ts
@@ -20,7 +20,7 @@ interface PageInfo {
 interface IssuePageResponse {
   repository: {
     issues: {
-      nodes: RawIssue[];
+      nodes: (RawIssue & {stateReason: string | null})[];
       pageInfo: PageInfo;
     };
   };
@@ -41,7 +41,7 @@ const PAGE_SIZE = 100;
 // 소문자 변환 후 하이픈/공백/언더스코어를 제거해 매칭합니다.
 export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
-  if (key === 'feat' || key === 'feature') return 'feature';
+  if (key === 'feat' || key === 'feature' || key === 'enhancement') return 'feature';
   if (key === 'bug') return 'bug';
   if (key === 'doc' || key === 'docs' || key === 'documentation') return 'doc';
   if (key === 'typo') return 'typo';
@@ -111,7 +111,7 @@ export const createGitHubService = (token: string) => {
     },
   });
 
-  const getAllClosedIssues = async (
+  const getAllIssues = async (
     owner: string,
     repo: string,
   ): Promise<IssueRecord[]> => {
@@ -133,7 +133,6 @@ export const createGitHubService = (token: string) => {
             issues(
               first: $pageSize
               after: $cursor
-              states: CLOSED
               orderBy: {field: CREATED_AT, direction: DESC}
             ) {
               nodes {
@@ -141,6 +140,7 @@ export const createGitHubService = (token: string) => {
                 title
                 url
                 state
+                stateReason
                 createdAt
                 closedAt
                 author { login }
@@ -160,7 +160,12 @@ export const createGitHubService = (token: string) => {
       const connection: IssuePageResponse['repository']['issues'] =
         response.repository.issues;
 
-      issues.push(...connection.nodes.map(toIssueRecord));
+      // 'not planned'와 'duplicate' 사유로 닫힌 이슈를 필터링합니다.
+      const validNodes = connection.nodes.filter(
+        node => node.stateReason !== 'NOT_PLANNED' && node.stateReason !== 'DUPLICATE'
+      );
+
+      issues.push(...validNodes.map(toIssueRecord));
 
       cursor = connection.pageInfo.endCursor;
       hasNextPage = connection.pageInfo.hasNextPage && cursor !== null;
@@ -240,7 +245,7 @@ export const createGitHubService = (token: string) => {
     if (cached) return cached.data;
 
     const [issues, prs] = await Promise.all([
-      getAllClosedIssues(owner, repo),
+      getAllIssues(owner, repo),
       getAllMergedPullRequests(owner, repo),
     ]);
 

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { cac } from "cac";
-import pkg from "./package.json" assert { type: "json"};
+import pkg from "./package.json" with { type: "json"};
 
 import {createGitHubService} from './github-service';
 import {ScoreCalculator, type RepoData} from './score-calculator';
@@ -8,10 +8,6 @@ import type {RepoSummary} from './output';
 
 const cli = cac("reposcore-ts");
 cli.version(pkg.version);
-
-
-
-
 
 const supportedFormats = ['csv', 'txt'] as const;
 type SupportedFormat = (typeof supportedFormats)[number];


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #164

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] normalizeLabel 에 enhancement 태그 조건 추가
- [ ] 이슈 쿼리에 open된 이슈 정보도 받아오도록 수정
- [ ] 이슈가 닫힌 이유가 NOT_PLANNED이거나 DUPLICATE 일경우 제외하도록 수정

### 🧪 테스트 방법 (선택 사항)
bun run index.ts oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --token {토큰} --no-cache

위코드를 실행하여 실제 점수와 맞는지 확인

### 💬 참고 사항 (선택 사항)

normalizeLabel 함수에서 라벨링할때 "enhancement"를 검사하지 않은것이 핵심 문제 였습니다.
깃헙 태그가 "enhancement"이기에 해당 태그를 검사해야하는데 순수하게 모든 코드를 AI한테 맡기면서
일반적인 feat 와 관련된 태그만 검사하도록 한것 같습니다.

그 외에도 정상적인 점수 계산을 위해 
open 되어 있는 이슈들도 받아오도록 수정했고
closed_reason, state_reason이 정상 종료인 completed 만 점수 계산에 반영되도록 수정했습니다.

