### PR TITLE
출력 형식 관련 상수 및 타입(SupportedFormat)을 src/output.ts로 이동

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,8 @@ import {
 import {
   summarizeRepo,
   writeOutputFiles,
+  supportedFormats,
+  type SupportedFormat,
   type RepoSummary,
 } from './src/output';
 import {
@@ -21,9 +23,6 @@ import {
 
 const cli = cac('reposcore-ts');
 cli.version(pkg.version);
-
-const supportedFormats = ['csv', 'txt'] as const;
-type SupportedFormat = (typeof supportedFormats)[number];
 
 function parseRepoPath(repoPath: string) {
   const parts = repoPath.split('/');

--- a/src/output.ts
+++ b/src/output.ts
@@ -7,6 +7,9 @@ const DEFAULT_OUTPUT_DIR = 'output';
 const CSV_FILENAME = 'scores.csv';
 const TXT_FILENAME = 'scores.txt';
 
+export const supportedFormats = ['csv', 'txt'] as const;
+export type SupportedFormat = (typeof supportedFormats)[number];
+
 export interface RepoSummary {
   repoPath: string;
   mergedPrFeatureBug: number;
@@ -169,7 +172,7 @@ export interface ScoreOutputData {
  * @returns 작성이 완료된 파일들의 경로 정보를 담은 Promise 객체
  */
 export const writeOutputFiles = async (
-  format: 'csv' | 'txt',
+  format: SupportedFormat,
   data: ScoreOutputData,
   outputDir: string = DEFAULT_OUTPUT_DIR,
   subDir?: string,


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #211 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] CLI 진입점(index.ts)에 결과 정렬을 위한 --sort-by <score|id> 및 --sort-order <asc|desc> 옵션 추가
- [ ] 사용자 점수 목록을 지정된 기준과 방식에 맞춰 정렬하는 sortUserScores 함수 구현 (src/sort.ts)
- [ ] score 기준 정렬 시 동점자가 발생할 경우, id 기준 오름차순(asc)으로 2차 정렬하여 항상 일관된 정렬 결과를 보장하도록 로직 추가
- [ ] 단일 저장소 출력 및 여러 저장소 합산(Total) 출력 로직에 파일 작성 전 정렬 적용 기능 연동

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
bun run index.ts oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts 실행

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
