### PR TITLE
bun run lint 명령어 실패 문제 패치

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,15 +2,8 @@ import {cac} from 'cac';
 import pkg from './package.json' with {type: 'json'};
 
 import {createGitHubService} from './src/github-service';
-import {
-  ScoreCalculator,
-  type RepoData,
-} from './src/score-calculator';
-import {
-  summarizeRepo,
-  writeOutputFiles,
-  type RepoSummary,
-} from './src/output';
+import {ScoreCalculator, type RepoData} from './src/score-calculator';
+import {summarizeRepo, writeOutputFiles, type RepoSummary} from './src/output';
 import {
   sortUserScores,
   supportedSortBys,


### PR DESCRIPTION
### ISSUE_ID
Closes #213

### 변경사항
- [x] `index.ts`의 짧은 multi-line import 2개를 Prettier 규칙에 맞게 single-line으로 수정

### 🧪 테스트 방법
1. 의존성 설치: `bun install`
2. lint 실행: `bun run lint`
3. 오류 없이 통과하는 것을 확인

### 💬 참고 사항
- `bun run typecheck` 및 `bun test`는 기존과 동일하게 통과합니다.
- Prettier가 print width 기준으로 충분히 짧은 import를 single-line으로 강제하는데, 해당 두 import가 그 기준을 만족하므로 single-line으로 변경했습니다.