### PR TITLE
캐시 데이터 증분 갱신 로직 추가

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,50 +1,14 @@
 const CACHE_DIR = '.cache';
 
-/**
- * 저장소별 분석 캐시 데이터 구조. JSON 파일로 직렬화되어 저장됩니다.
- *
- * @template T 캐시에 저장되는 실제 데이터의 타입
- */
 export interface RepoCache<T> {
-  /** `owner/repo` 형식의 저장소 식별자. */
   repository: string;
-  /** 마지막으로 분석을 수행한 시각 (ISO 8601 형식). */
-  lastAnalyzedAt: string; // ISO 8601
-  /** 캐시된 분석 결과 데이터. */
+  lastAnalyzedAt: string;
   data: T;
 }
 
-/**
- * 저장소 소유자와 이름을 기반으로 캐시 파일의 경로를 반환합니다.
- *
- * @param owner 저장소 소유자 ID 혹은 조직명
- * @param repo 저장소 이름
- * @returns `.cache/<owner>_<repo>/cache.json` 형식의 파일 경로 문자열
- */
 const getCacheFilePath = (owner: string, repo: string): string =>
   `${CACHE_DIR}/${owner}_${repo}/cache.json`;
 
-/**
- * 기존 캐시 파일을 읽어 {@link RepoCache} 객체를 반환합니다.
- *
- * 다음의 경우 `null`을 반환합니다:
- * - `noCache`가 `true`인 경우
- * - 캐시 파일이 존재하지 않는 경우
- * - 캐시 파일이 손상되었거나 파싱에 실패한 경우
- * - 캐시 파일에 기록된 저장소 식별자가 `owner/repo`와 일치하지 않는 경우
- *
- * @template T 캐시에 저장된 실제 데이터의 타입
- * @param owner 저장소 소유자 ID 혹은 조직명
- * @param repo 저장소 이름
- * @param noCache `true`이면 캐시를 무시하고 즉시 `null`을 반환합니다 (기본값: `false`)
- * @returns 유효한 캐시가 있으면 {@link RepoCache} 객체, 없으면 `null`
- *
- * @example
- * const cache = await loadCache<DetailedRepoData>('oss2026hnu', 'reposcore-ts');
- * if (cache) {
- *   console.log('캐시 히트:', cache.lastAnalyzedAt);
- * }
- */
 export const loadCache = async <T>(
   owner: string,
   repo: string,
@@ -62,6 +26,7 @@ export const loadCache = async <T>(
 
   try {
     const cache = (await file.json()) as RepoCache<T>;
+
     if (cache.repository !== `${owner}/${repo}`) return null;
 
     console.error(`[cache] ${owner}/${repo} — 캐시에서 읽습니다.`);
@@ -72,29 +37,15 @@ export const loadCache = async <T>(
   }
 };
 
-/**
- * 분석 결과를 {@link RepoCache} 형식으로 JSON 파일에 저장합니다.
- *
- * 저장 시각(`lastAnalyzedAt`)은 호출 시점의 현재 시각으로 자동 기록됩니다.
- * 대상 디렉터리가 없는 경우 Bun이 자동으로 생성합니다.
- *
- * @template T 캐시에 저장할 실제 데이터의 타입
- * @param owner 저장소 소유자 ID 혹은 조직명
- * @param repo 저장소 이름
- * @param data 저장할 분석 결과 데이터
- * @returns 저장 완료 후 resolve되는 `Promise<void>`
- *
- * @example
- * await saveCache('oss2026hnu', 'reposcore-ts', detailedRepoData);
- */
 export const saveCache = async <T>(
   owner: string,
   repo: string,
   data: T,
+  analyzedAt = new Date().toISOString(),
 ): Promise<void> => {
   const cache: RepoCache<T> = {
     repository: `${owner}/${repo}`,
-    lastAnalyzedAt: new Date().toISOString(),
+    lastAnalyzedAt: analyzedAt,
     data,
   };
 
@@ -102,5 +53,6 @@ export const saveCache = async <T>(
     getCacheFilePath(owner, repo),
     JSON.stringify(cache, null, 2),
   );
+
   console.error(`[cache] ${owner}/${repo} — 캐시를 저장했습니다.`);
 };

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -35,16 +35,22 @@ interface PullRequestPageResponse {
   };
 }
 
+interface IssueSearchResponse {
+  search: {
+    nodes: (RawIssue & {stateReason: string | null})[];
+    pageInfo: PageInfo;
+  };
+}
+
+interface PullRequestSearchResponse {
+  search: {
+    nodes: RawPullRequest[];
+    pageInfo: PageInfo;
+  };
+}
+
 const PAGE_SIZE = 100;
 
-/**
- * 라벨 문자열을 ContributionLabel 카테고리로 정규화합니다.
- * * 소문자 변환 후 하이픈, 공백, 언더스코어를 제거하여 매칭합니다.
- * 인식되지 않는 라벨인 경우 'none'을 반환합니다.
- *
- * @param label 정규화할 원본 라벨 문자열
- * @returns 정규화된 ContributionLabel 카테고리 종류
- */
 export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
   if (key === 'feat' || key === 'feature' || key === 'enhancement')
@@ -55,15 +61,6 @@ export const normalizeLabel = (label: string): ContributionLabel => {
   return 'none';
 };
 
-/**
- * 라벨 배열에서 첫 번째로 인식되는 ContributionLabel을 반환합니다.
- *
- * 배열을 순회하며 인식 가능한 유효 라벨이 발견되면 즉시 반환하고,
- * 유효한 라벨이 하나도 없으면 'none'을 반환합니다.
- *
- * @param labels 검사할 원본 라벨 문자열 배열
- * @returns 분류된 첫 번째 유효 ContributionLabel 카테고리
- */
 export const categorizeLabels = (labels: string[]): ContributionLabel => {
   for (const label of labels) {
     const category = normalizeLabel(label);
@@ -71,49 +68,66 @@ export const categorizeLabels = (labels: string[]): ContributionLabel => {
       return category;
     }
   }
+
   return 'none';
 };
 
-/**
- * GitHub API 응답 객체에서 라벨 이름들만 문자열 배열로 추출합니다.
- *
- * @param labels GraphQL 응답에서 받아온 라벨 노드 객체 또는 null
- * @returns 추출된 라벨 이름 문자열 배열
- */
 const extractLabelNames = (
   labels: {nodes: {name: string}[]} | null,
 ): string[] => {
   if (!labels || !labels.nodes) return [];
+
   return labels.nodes.map(node => node.name).filter(name => Boolean(name));
 };
 
-/**
- * GraphQL로 받아온 원본 이슈 데이터를 시스템 표준 IssueRecord 형식으로 변환합니다.
- *
- * @param raw 라벨 가공 전의 원본 이슈 데이터
- * @returns 카테고리 정보가 포함되어 가공된 IssueRecord 객체
- */
-const toIssueRecord = (raw: RawIssue): IssueRecord => {
+const toIssueRecord = (
+  raw: RawIssue & {stateReason?: string | null},
+): IssueRecord => {
   return {
-    ...raw,
+    number: raw.number,
+    title: raw.title,
+    url: raw.url,
+    state: raw.state,
+    createdAt: raw.createdAt,
+    closedAt: raw.closedAt,
+    author: raw.author,
+    labels: raw.labels,
     category: categorizeLabels(extractLabelNames(raw.labels)),
   };
 };
 
-/**
- * GraphQL로 받아온 원본 Pull Request 데이터를 시스템 표준 PRRecord 형식으로 변환합니다.
- *
- * @param raw 라벨 가공 전의 원본 Pull Request 데이터
- * @returns 카테고리 정보가 포함되어 가공된 PRRecord 객체
- */
 const toPrRecord = (raw: RawPullRequest): PRRecord => {
   return {
-    ...raw,
+    number: raw.number,
+    title: raw.title,
+    url: raw.url,
+    merged: raw.merged,
+    mergedAt: raw.mergedAt,
+    additions: raw.additions,
+    deletions: raw.deletions,
+    author: raw.author,
+    labels: raw.labels,
     category: categorizeLabels(extractLabelNames(raw.labels)),
   };
 };
 
-// DetailedRepoData에서 카테고리별 개수를 집계합니다.
+const mergeByNumber = <T extends {number: number}>(
+  cachedItems: T[],
+  updatedItems: T[],
+): T[] => {
+  const itemMap = new Map<number, T>();
+
+  for (const item of cachedItems) {
+    itemMap.set(item.number, item);
+  }
+
+  for (const item of updatedItems) {
+    itemMap.set(item.number, item);
+  }
+
+  return [...itemMap.values()].sort((a, b) => b.number - a.number);
+};
+
 export interface CategoryCounts {
   feature: number;
   bug: number;
@@ -121,12 +135,7 @@ export interface CategoryCounts {
   typo: number;
   none: number;
 }
-/**
- * 데이터 목록에서 각 기여 카테고리(Feature, Bug, Doc 등)별 발생 개수를 집계합니다.
- *
- * @param records 카테고리 정보가 포함된 기여 데이터 배열
- * @returns 카테고리별 집계 개수가 담긴 CategoryCounts 객체
- */
+
 export const countByCategory = (
   records: ReadonlyArray<{category: ContributionLabel}>,
 ): CategoryCounts => {
@@ -137,18 +146,14 @@ export const countByCategory = (
     typo: 0,
     none: 0,
   };
+
   for (const record of records) {
     counts[record.category] += 1;
   }
+
   return counts;
 };
 
-/**
- * GitHub GraphQL API 통신을 담당하는 GitHub 서비스 인스턴스를 생성합니다.
- *
- * @param token GitHub API 호출에 사용할 개인 접근 토큰 (Personal Access Token)
- * @returns 저장소 데이터 조회가 가능한 기능 객체
- */
 export const createGitHubService = (token: string) => {
   const githubGraphQL = graphql.defaults({
     headers: {
@@ -156,14 +161,6 @@ export const createGitHubService = (token: string) => {
     },
   });
 
-  /**
-   * 대상 저장소에서 모든 이슈 데이터를 조회합니다.
-   * * GraphQL 기반의 cursor 페이지네이션을 이용하여 모든 페이지의 데이터를 순회 수집합니다.
-   *
-   * @param owner 저장소 소유자 ID 혹은 조직명
-   * @param repo 저장소 이름
-   * @returns 가공된 전체 IssueRecord 데이터 배열
-   */
   const getAllValidIssues = async (
     owner: string,
     repo: string,
@@ -176,46 +173,46 @@ export const createGitHubService = (token: string) => {
       const response: IssuePageResponse =
         await githubGraphQL<IssuePageResponse>(
           `
-        query(
-          $owner: String!
-          $repo: String!
-          $pageSize: Int!
-          $cursor: String
-        ) {
-          repository(owner: $owner, name: $repo) {
-            issues(
-              first: $pageSize
-              after: $cursor
-              orderBy: {field: CREATED_AT, direction: DESC}
-            ) {
-              nodes {
-                number
-                title
-                url
-                state
-                stateReason
-                createdAt
-                closedAt
-                author { login }
-                labels(first: 20) { nodes { name } }
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
+          query(
+            $owner: String!
+            $repo: String!
+            $pageSize: Int!
+            $cursor: String
+          ) {
+            repository(owner: $owner, name: $repo) {
+              issues(
+                first: $pageSize
+                after: $cursor
+                orderBy: {field: CREATED_AT, direction: DESC}
+              ) {
+                nodes {
+                  number
+                  title
+                  url
+                  state
+                  stateReason
+                  createdAt
+                  closedAt
+                  author { login }
+                  labels(first: 20) { nodes { name } }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
             }
           }
-        }
-        `,
+          `,
           {owner, repo, pageSize: PAGE_SIZE, cursor},
         );
 
       const connection: IssuePageResponse['repository']['issues'] =
         response.repository.issues;
 
-      // OPEN 상태이거나 CLOSE된 상태 중에서도 정상적으로 종료된(COMPLETED) 이슈만 유효한 데이터로 필터링합니다.
       const validNodes = connection.nodes.filter(
-        node => node.state === 'OPEN' || node.stateReason === 'COMPLETED',
+        (node: RawIssue & {stateReason: string | null}) =>
+          node.state === 'OPEN' || node.stateReason === 'COMPLETED',
       );
 
       issues.push(...validNodes.map(toIssueRecord));
@@ -227,15 +224,6 @@ export const createGitHubService = (token: string) => {
     return issues;
   };
 
-  /**
-   * 대상 저장소에서 병합된(MERGED) 상태의 모든 Pull Request 데이터를 조회합니다.
-   *
-   * GraphQL 기반의 cursor 페이지네이션을 이용하여 모든 페이지의 데이터를 순회 수집합니다.
-   *
-   * @param owner 저장소 소유자 ID 혹은 조직명
-   * @param repo 저장소 이름
-   * @returns 가공된 전체 PRRecord 데이터 배열
-   */
   const getAllMergedPullRequests = async (
     owner: string,
     repo: string,
@@ -248,38 +236,38 @@ export const createGitHubService = (token: string) => {
       const response: PullRequestPageResponse =
         await githubGraphQL<PullRequestPageResponse>(
           `
-        query(
-          $owner: String!
-          $repo: String!
-          $pageSize: Int!
-          $cursor: String
-        ) {
-          repository(owner: $owner, name: $repo) {
-            pullRequests(
-              first: $pageSize
-              after: $cursor
-              states: MERGED
-              orderBy: {field: CREATED_AT, direction: DESC}
-            ) {
-              nodes {
-                number
-                title
-                url
-                merged
-                mergedAt
-                additions
-                deletions
-                author { login }
-                labels(first: 20) { nodes { name } }
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
+          query(
+            $owner: String!
+            $repo: String!
+            $pageSize: Int!
+            $cursor: String
+          ) {
+            repository(owner: $owner, name: $repo) {
+              pullRequests(
+                first: $pageSize
+                after: $cursor
+                states: MERGED
+                orderBy: {field: CREATED_AT, direction: DESC}
+              ) {
+                nodes {
+                  number
+                  title
+                  url
+                  merged
+                  mergedAt
+                  additions
+                  deletions
+                  author { login }
+                  labels(first: 20) { nodes { name } }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
             }
           }
-        }
-        `,
+          `,
           {owner, repo, pageSize: PAGE_SIZE, cursor},
         );
 
@@ -295,36 +283,166 @@ export const createGitHubService = (token: string) => {
     return prs;
   };
 
-  /**
-   * Closed 이슈와 Merged PR 데이터를 각각 cursor 기반 페이지네이션으로 통합 조회합니다.
-   *
-   * useCache 가 true(기본값)인 경우 로컬 캐시 파일(.cache/<owner>_<repo>.json)을 우선적으로 확인하며,
-   * 캐시가 없거나 useCache 가 false인 경우에만 GitHub API를 원격 호출한 후 결과를 다시 캐싱합니다.
-   *
-   * @param owner 저장소 소유자 ID 혹은 조직명
-   * @param repo 저장소 이름
-   * @param useCache 파일 캐시 시스템 적용 여부 (기본값: true)
-   * @returns 이슈와 PR 데이터가 통합된 DetailedRepoData 객체
-   */
+  const getUpdatedValidIssues = async (
+    owner: string,
+    repo: string,
+    since: string,
+  ): Promise<IssueRecord[]> => {
+    const issues: IssueRecord[] = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const response: IssueSearchResponse =
+        await githubGraphQL<IssueSearchResponse>(
+          `
+          query(
+            $query: String!
+            $pageSize: Int!
+            $cursor: String
+          ) {
+            search(
+              query: $query
+              type: ISSUE
+              first: $pageSize
+              after: $cursor
+            ) {
+              nodes {
+                ... on Issue {
+                  number
+                  title
+                  url
+                  state
+                  stateReason
+                  createdAt
+                  closedAt
+                  author { login }
+                  labels(first: 20) { nodes { name } }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+          `,
+          {
+            query: `repo:${owner}/${repo} is:issue updated:>=${since}`,
+            pageSize: PAGE_SIZE,
+            cursor,
+          },
+        );
+
+      const validNodes = response.search.nodes.filter(
+        (node: RawIssue & {stateReason: string | null}) =>
+          node.state === 'OPEN' || node.stateReason === 'COMPLETED',
+      );
+
+      issues.push(...validNodes.map(toIssueRecord));
+
+      cursor = response.search.pageInfo.endCursor;
+      hasNextPage = response.search.pageInfo.hasNextPage && cursor !== null;
+    }
+
+    return issues;
+  };
+
+  const getUpdatedMergedPullRequests = async (
+    owner: string,
+    repo: string,
+    since: string,
+  ): Promise<PRRecord[]> => {
+    const prs: PRRecord[] = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const response: PullRequestSearchResponse =
+        await githubGraphQL<PullRequestSearchResponse>(
+          `
+          query(
+            $query: String!
+            $pageSize: Int!
+            $cursor: String
+          ) {
+            search(
+              query: $query
+              type: ISSUE
+              first: $pageSize
+              after: $cursor
+            ) {
+              nodes {
+                ... on PullRequest {
+                  number
+                  title
+                  url
+                  merged
+                  mergedAt
+                  additions
+                  deletions
+                  author { login }
+                  labels(first: 20) { nodes { name } }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+          `,
+          {
+            query: `repo:${owner}/${repo} is:pr is:merged updated:>=${since}`,
+            pageSize: PAGE_SIZE,
+            cursor,
+          },
+        );
+
+      prs.push(...response.search.nodes.map(toPrRecord));
+
+      cursor = response.search.pageInfo.endCursor;
+      hasNextPage = response.search.pageInfo.hasNextPage && cursor !== null;
+    }
+
+    return prs;
+  };
+
   const getDetailedRepoData = async (
     owner: string,
     repo: string,
     useCache = true,
   ): Promise<DetailedRepoData> => {
+    const analysisStartedAt = new Date().toISOString();
     const cached = await loadCache<DetailedRepoData>(owner, repo, !useCache);
-    if (cached) return cached.data;
 
-    const [issues, prs] = await Promise.all([
-      getAllValidIssues(owner, repo),
-      getAllMergedPullRequests(owner, repo),
+    if (!cached) {
+      const [issues, prs] = await Promise.all([
+        getAllValidIssues(owner, repo),
+        getAllMergedPullRequests(owner, repo),
+      ]);
+
+      const data: DetailedRepoData = {
+        prs,
+        issues,
+      };
+
+      await saveCache(owner, repo, data, analysisStartedAt);
+
+      return data;
+    }
+
+    const [updatedIssues, updatedPrs] = await Promise.all([
+      getUpdatedValidIssues(owner, repo, cached.lastAnalyzedAt),
+      getUpdatedMergedPullRequests(owner, repo, cached.lastAnalyzedAt),
     ]);
 
     const data: DetailedRepoData = {
-      issues,
-      prs,
+      prs: mergeByNumber(cached.data.prs, updatedPrs),
+      issues: mergeByNumber(cached.data.issues, updatedIssues),
     };
 
-    await saveCache(owner, repo, data);
+    await saveCache(owner, repo, data, analysisStartedAt);
 
     return data;
   };


### PR DESCRIPTION
### ISSUE_ID
Closes #214

### 변경사항
1. 기존 캐시 존재 시 즉시 반환하던 로직을 제거하고 증분 갱신(Incremental Update) 로직 추가
2. lastAnalyzedAt 이후 변경된 Issue 및 Pull Request만 GitHub GraphQL Search API를 통해 조회하도록 구현
3. 신규 조회 데이터와 기존 캐시 데이터를 번호(number) 기준으로 병합한 후 캐시를 갱신하도록 수정
4. 분석 시작 시각을 기준으로 lastAnalyzedAt을 저장하도록 개선하여 조회 중 발생한 변경 사항 누락 가능성 완화
5. saveCache()에 분석 시각을 전달할 수 있도록 캐시 저장 로직 개선

### 🧪 테스트 방법 (선택 사항)
1. bun run typecheck 실행
2. 최초 실행으로 캐시 생성
3. 저장소에 새로운 PR 또는 Issue 변경 사항 추가
4. --no-cache 없이 재실행
5. 변경된 데이터가 결과 및 캐시에 반영되는지 확인

### 💬 참고 사항 (선택 사항)
기존에는 캐시 파일이 존재하면 GitHub API를 호출하지 않고 캐시 데이터를 그대로 반환했습니다.
이번 변경으로 캐시를 기반으로 하되, 마지막 분석 시점 이후 변경된 데이터만 추가 조회하여 최신 상태를 유지하도록 개선했습니다.
전체 데이터를 다시 수집하지 않고 변경분만 조회하므로 API 호출량을 줄이면서 최신성을 확보할 수 있습니다.
