### PR TITLE
--format 옵션 다중 출력 형식 지정 기능 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,8 +2,14 @@ import {cac} from 'cac';
 import pkg from './package.json' with {type: 'json'};
 
 import {createGitHubService} from './src/github-service';
-import { ScoreCalculator, type RepoData } from './src/score-calculator';
-import { summarizeRepo, writeOutputFiles, supportedFormats, type SupportedFormat, type RepoSummary } from './src/output';
+import {ScoreCalculator, type RepoData} from './src/score-calculator';
+import {
+  summarizeRepo,
+  writeOutputFiles,
+  supportedFormats,
+  type SupportedFormat,
+  type RepoSummary,
+} from './src/output';
 import {
   sortUserScores,
   supportedSortBys,
@@ -62,7 +68,11 @@ cli
         options.token === '$GITHUB_TOKEN'
           ? Bun.env.GITHUB_TOKEN || ''
           : options.token || '';
-      const format = String(options.format || '').toLowerCase();
+      const formats = String(options.format || 'csv')
+        .toLowerCase()
+        .split(',')
+        .map(format => format.trim())
+        .filter(Boolean);
       const useCache = options.cache; // --no-cache 전달 시 false
       const outputDir = options.outputDir || 'output';
       const sortBy = String(options.sortBy || 'score').toLowerCase();
@@ -80,9 +90,13 @@ cli
         );
       }
 
-      if (!supportedFormats.includes(format as SupportedFormat)) {
+      const invalidFormats = formats.filter(
+        format => !supportedFormats.includes(format as SupportedFormat),
+      );
+
+      if (invalidFormats.length > 0) {
         errors.push(
-          `오류: 지원하지 않는 출력 형식 '${options.format}'입니다. csv, txt 또는 html을 입력하세요.`,
+          `오류: 지원하지 않는 출력 형식 '${invalidFormats.join(', ')}'입니다. csv, txt 또는 html을 입력하세요.`,
         );
       }
 
@@ -128,7 +142,7 @@ cli
         process.exit(1);
       }
 
-      console.error(`형식: ${format}`);
+      console.error(`형식: ${formats.join(', ')}`);
       console.error(`저장소: ${repos.join(', ')}`);
 
       const githubService = createGitHubService(token);
@@ -161,7 +175,7 @@ cli
 
           const subDir = `${owner}-${repoName}`;
           const written = await writeOutputFiles(
-            format as SupportedFormat,
+            formats as SupportedFormat[],
             {
               userScores: singleUserScores,
               repoSummaries: [repoSummary],
@@ -193,7 +207,7 @@ cli
       );
 
       const written = await writeOutputFiles(
-        format as SupportedFormat,
+        formats as SupportedFormat[],
         {
           userScores,
           repoSummaries,

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -297,12 +297,12 @@ export const createGitHubService = (token: string) => {
         await githubGraphQL<IssueSearchResponse>(
           `
           query(
-            $query: String!
+            $searchQuery: String!
             $pageSize: Int!
             $cursor: String
           ) {
             search(
-              query: $query
+              query: $searchQuery
               type: ISSUE
               first: $pageSize
               after: $cursor
@@ -328,7 +328,7 @@ export const createGitHubService = (token: string) => {
           }
           `,
           {
-            query: `repo:${owner}/${repo} is:issue updated:>=${since}`,
+            searchQuery: `repo:${owner}/${repo} is:issue updated:>=${since}`,
             pageSize: PAGE_SIZE,
             cursor,
           },
@@ -362,12 +362,12 @@ export const createGitHubService = (token: string) => {
         await githubGraphQL<PullRequestSearchResponse>(
           `
           query(
-            $query: String!
+            $searchQuery: String!
             $pageSize: Int!
             $cursor: String
           ) {
             search(
-              query: $query
+              query: $searchQuery
               type: ISSUE
               first: $pageSize
               after: $cursor
@@ -393,7 +393,7 @@ export const createGitHubService = (token: string) => {
           }
           `,
           {
-            query: `repo:${owner}/${repo} is:pr is:merged updated:>=${since}`,
+            searchQuery: `repo:${owner}/${repo} is:pr is:merged updated:>=${since}`,
             pageSize: PAGE_SIZE,
             cursor,
           },

--- a/src/output.ts
+++ b/src/output.ts
@@ -283,7 +283,7 @@ export const buildHtmlReport = (data: ScoreOutputData): string => {
  * @returns 작성이 완료된 파일들의 경로 정보를 담은 Promise 객체
  */
 export const writeOutputFiles = async (
-  format: SupportedFormat,
+  formats: ReadonlyArray<SupportedFormat>,
   data: ScoreOutputData,
   outputDir: string = DEFAULT_OUTPUT_DIR,
   subDir?: string,
@@ -295,20 +295,24 @@ export const writeOutputFiles = async (
 
   await Bun.write(paths.csv, buildUserScoresCsv(data.userScores));
 
-  if (format === 'txt') {
+  const written: {csv: string; txt?: string; html?: string} = {
+    csv: paths.csv,
+  };
+
+  if (formats.includes('txt')) {
     // 💡 기존 저장소 요약 하단에 사용자별 점수 요약본을 개행('\n')으로 결합하여 저장합니다.
     const repoSummariesTxt = buildRepoSummariesTxt(data.repoSummaries);
     const userScoresTxt = buildUserScoresTxt(data.userScores);
 
     await Bun.write(paths.txt, repoSummariesTxt + '\n' + userScoresTxt);
-    return {csv: paths.csv, txt: paths.txt};
+    written.txt = paths.txt;
   }
 
-  if (format === 'html') {
+  if (formats.includes('html')) {
     const htmlReport = buildHtmlReport(data);
     await Bun.write(paths.html, htmlReport);
-    return {csv: paths.csv, html: paths.html};
+    written.html = paths.html;
   }
 
-  return {csv: paths.csv};
+  return written;
 };


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/216

### 변경사항
- [x] index.ts에서 --format 옵션을 쉼표(,) 기준으로 분리하여 여러 출력 형식을 입력받을 수 있도록 수정
- [x] output.ts의 writeOutputFiles()를 수정하여 CSV, TXT, HTML 파일을 동시에 생성할 수 있도록 변경
- [x] 지원하지 않는 출력 형식이 포함된 경우 오류 메시지를 출력하도록 검증 로직 수정
- [x] github-service.ts에서 캐시 사용 시 발생하던 GraphQL 변수명 충돌 문제 수정

### 🧪 테스트 방법 (선택 사항)
- bun run index.ts oss2026hnu/reposcore-ts --format=csv,html
- bun run index.ts oss2026hnu/reposcore-ts --format=csv,txt,html

### 💬 참고 사항 (선택 사항)
- 테스트 과정에서 캐시가 새로 생성된 후 동일한 저장소를 다시 실행했을 때, 캐시를 읽어 변경분을 조회하는 과정에서 [@octokit/graphql] "query" cannot be used as variable name 오류가 발생하는 것을 확인했습니다.
- 해당 오류로 인해 캐시가 존재하는 상태에서 재실행 시 결과 파일 생성이 중단되었으며, 캐시 갱신용 GraphQL 쿼리에서 사용하던 변수명 query를 searchQuery로 변경하여 문제를 해결했습니다.
