### PR TITLE
[FEAT] txt 리포트 가독성 개선

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -80,6 +80,80 @@ const USER_CSV_HEADERS = [
   'totalScore',
 ] as const;
 
+interface UserContributionCounts {
+  userId: string;
+  prFeatureBug: number;
+  prDocs: number;
+  prTypo: number;
+  issueFeatureBug: number;
+  issueDocs: number;
+  totalScore: number;
+}
+
+const aggregateUserContribution = (user: UserScore): UserContributionCounts => {
+  let prFeatureBug = 0;
+  let prDocs = 0;
+  let prTypo = 0;
+  let issueFeatureBug = 0;
+  let issueDocs = 0;
+
+  for (const repo of user.repoScores) {
+    for (const data of repo.scoreData) {
+      prFeatureBug += data.prFeatureBug;
+      prDocs += data.prDocs;
+      prTypo += data.prTypo;
+      issueFeatureBug += data.issueFeatureBug;
+      issueDocs += data.issueDocs;
+    }
+  }
+
+  return {
+    userId: user.userId,
+    prFeatureBug,
+    prDocs,
+    prTypo,
+    issueFeatureBug,
+    issueDocs,
+    totalScore: user.totalScore,
+  };
+};
+
+const formatDateTime = (date: Date): string => {
+  const pad = (value: number): string => String(value).padStart(2, '0');
+  return (
+    [date.getFullYear(), pad(date.getMonth() + 1), pad(date.getDate())].join(
+      '-',
+    ) + ` ${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+};
+
+const buildMarkdownTable = (
+  headers: readonly string[],
+  rows: ReadonlyArray<readonly string[]>,
+  rightAlignedColumns: ReadonlySet<number>,
+): string[] => {
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map(row => row[index]?.length ?? 0)),
+  );
+  const formatRow = (cells: readonly string[]): string =>
+    `| ${cells
+      .map((cell, index) =>
+        rightAlignedColumns.has(index)
+          ? cell.padStart(widths[index]!)
+          : cell.padEnd(widths[index]!),
+      )
+      .join(' | ')} |`;
+  const separator = `| ${widths
+    .map((width, index) =>
+      rightAlignedColumns.has(index)
+        ? `${'-'.repeat(Math.max(width - 1, 1))}:`
+        : '-'.repeat(width),
+    )
+    .join(' | ')} |`;
+
+  return [formatRow(headers), separator, ...rows.map(formatRow)];
+};
+
 /**
  * 전체 사용자 점수 목록을 받아 CSV 파일에 기록할 텍스트 문자열을 빌드합니다.
  *
@@ -88,74 +162,114 @@ const USER_CSV_HEADERS = [
  */
 export const buildUserScoresCsv = (users: ReadonlyArray<UserScore>): string => {
   const rows = users.map(user => {
-    let prFeatureBug = 0;
-    let prDocs = 0;
-    let prTypo = 0;
-    let issueFeatureBug = 0;
-    let issueDocs = 0;
-    for (const repo of user.repoScores) {
-      for (const data of repo.scoreData) {
-        prFeatureBug += data.prFeatureBug;
-        prDocs += data.prDocs;
-        prTypo += data.prTypo;
-        issueFeatureBug += data.issueFeatureBug;
-        issueDocs += data.issueDocs;
-      }
-    }
-    return [
-      user.userId,
+    const {
+      userId,
       prFeatureBug,
       prDocs,
       prTypo,
       issueFeatureBug,
       issueDocs,
-      user.totalScore,
+      totalScore,
+    } = aggregateUserContribution(user);
+
+    return [
+      userId,
+      prFeatureBug,
+      prDocs,
+      prTypo,
+      issueFeatureBug,
+      issueDocs,
+      totalScore,
     ].join(',');
   });
   return [USER_CSV_HEADERS.join(','), ...rows].join('\n') + '\n';
 };
 
-// 저장소별 카테고리 요약을 사람이 읽기 좋은 TXT 블록으로 만듭니다.
-export const buildRepoSummariesTxt = (
-  summaries: ReadonlyArray<RepoSummary>,
-): string => {
-  const blocks = summaries.map(s =>
-    [
-      `[${s.repoPath}]`,
-      `Merged PRs - feature/bug: ${s.mergedPrFeatureBug}, docs: ${s.mergedPrDocs}, typo: ${s.mergedPrTypo}`,
-      `Closed Issues - feature/bug: ${s.closedIssueFeatureBug}, docs: ${s.closedIssueDocs}`,
-    ].join('\n'),
-  );
-  return blocks.join('\n\n') + '\n';
-};
-
 /**
  * 저장소 요약 데이터 정보와 전체 사용자 점수 데이터를 가독성 있는 텍스트(TXT) 포맷 문자열로 빌드합니다.
  *
- * @param repos 저장소별 요약 기여 데이터 정보 배열
- * @param userScores 전체 사용자별 최종 합산 점수 및 상세 기여 데이터 배열
+ * @param data 저장소 요약 및 사용자 점수 데이터 정보 객체
+ * @param analyzedAt 리포트 분석 시각
  * @returns 텍스트(TXT) 파일용 보고서 문자열
  */
-export const buildUserScoresTxt = (users: ReadonlyArray<UserScore>): string => {
-  const lines = users.map(user => {
-    let prFeatureBug = 0;
-    let prDocs = 0;
-    let prTypo = 0;
-    let issueFeatureBug = 0;
-    let issueDocs = 0;
-    for (const repo of user.repoScores) {
-      for (const data of repo.scoreData) {
-        prFeatureBug += data.prFeatureBug;
-        prDocs += data.prDocs;
-        prTypo += data.prTypo;
-        issueFeatureBug += data.issueFeatureBug;
-        issueDocs += data.issueDocs;
-      }
-    }
-    return `- ${user.userId}: totalScore=${user.totalScore}, PR(feature/bug)=${prFeatureBug}, PR(docs)=${prDocs}, PR(typo)=${prTypo}, Issue(feature/bug)=${issueFeatureBug}, Issue(docs)=${issueDocs}`;
-  });
+export const buildUserScoresTxt = (
+  data: ScoreOutputData,
+  analyzedAt: Date = new Date(),
+): string => {
+  const repoLabel = data.repoSummaries
+    .map(summary => summary.repoPath)
+    .join(' + ');
+  const rows = data.userScores.map(aggregateUserContribution);
+  const lines = [
+    `=== ${repoLabel} 오픈소스 기여도 분석 리포트 ===`,
+    `분석 일시: ${formatDateTime(analyzedAt)}`,
+    '',
+  ];
+  const tableRows: string[][] = [];
+  const rejections: string[] = [];
 
-  return ['User Scores', ...lines].join('\n') + '\n';
+  for (const row of rows) {
+    const totalIssues = row.issueDocs + row.issueFeatureBug;
+    const totalPrs = row.prDocs + row.prFeatureBug + row.prTypo;
+
+    tableRows.push([
+      row.userId,
+      `${totalIssues} (${row.issueDocs}/${row.issueFeatureBug})`,
+      `${totalPrs} (${row.prDocs}/${row.prFeatureBug}/${row.prTypo})`,
+      String(row.totalScore),
+    ]);
+
+    const maxAdditionalPr = 3 * Math.max(row.prFeatureBug, 1);
+    const totalDocTypoPr = row.prDocs + row.prTypo;
+    const rejectedPr = Math.max(0, totalDocTypoPr - maxAdditionalPr);
+    const validPrCount =
+      row.prFeatureBug + Math.min(totalDocTypoPr, maxAdditionalPr);
+    const maxIssueCount = 4 * validPrCount;
+    const rejectedIssue = Math.max(0, totalIssues - maxIssueCount);
+
+    if (rejectedPr > 0 || rejectedIssue > 0) {
+      const userRejections = [
+        `${row.userId}:`,
+        `   [미인정 항목] 문서/오타 PR ${rejectedPr}개 초과(한도 ${maxAdditionalPr}개) / 이슈 ${rejectedIssue}개 초과(한도 ${maxIssueCount}개)`,
+      ];
+
+      if (rejectedPr > 0) {
+        const docSuggestionCount = Math.ceil(rejectedPr / 3);
+        userRejections.push(
+          `   [추가 제안] 기능/버그 PR ${docSuggestionCount}개 추가 시 문서PR 인정 한도 +${docSuggestionCount * 3}`,
+        );
+      }
+
+      if (rejectedIssue > 0) {
+        const issueSuggestionCount = Math.ceil(rejectedIssue / 4);
+        if (totalDocTypoPr < maxAdditionalPr) {
+          userRejections.push(
+            `   [추가 제안] 문서 PR ${issueSuggestionCount}개 추가 혹은 기능/버그 PR ${issueSuggestionCount}개 추가시 이슈 인정한도 +${issueSuggestionCount * 4}`,
+          );
+        } else {
+          userRejections.push(
+            `   [추가 제안] 기능/버그 PR ${issueSuggestionCount}개 추가시 이슈 인정한도 +${issueSuggestionCount * 4}`,
+          );
+        }
+      }
+
+      rejections.push(userRejections.join('\n'));
+    }
+  }
+
+  lines.push(
+    ...buildMarkdownTable(
+      ['User', 'Issues (Docs/Features)', 'PR (Docs/Features/Typo)', 'Score'],
+      tableRows,
+      new Set([1, 2, 3]),
+    ),
+  );
+
+  if (rejections.length > 0) {
+    lines.push('', '=== 미인정 항목 및 추가 제안 ===', '', ...rejections);
+  }
+
+  return lines.join('\n') + '\n';
 };
 
 export interface ScoreOutputData {
@@ -300,11 +414,8 @@ export const writeOutputFiles = async (
   };
 
   if (formats.includes('txt')) {
-    // 💡 기존 저장소 요약 하단에 사용자별 점수 요약본을 개행('\n')으로 결합하여 저장합니다.
-    const repoSummariesTxt = buildRepoSummariesTxt(data.repoSummaries);
-    const userScoresTxt = buildUserScoresTxt(data.userScores);
-
-    await Bun.write(paths.txt, repoSummariesTxt + '\n' + userScoresTxt);
+    const userScoresTxt = buildUserScoresTxt(data);
+    await Bun.write(paths.txt, userScoresTxt);
     written.txt = paths.txt;
   }
 

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, test} from 'bun:test';
+import {buildUserScoresTxt, type ScoreOutputData} from '../src/output';
+
+const analyzedAt = new Date(2026, 5, 4, 9, 30);
+
+describe('TXT 리포트 출력', () => {
+  test('reposcore-cs와 같은 제목, 분석 일시, Markdown 표 형식으로 출력해야 한다', () => {
+    const data: ScoreOutputData = {
+      repoSummaries: [
+        {
+          repoPath: 'oss2026hnu/reposcore-ts',
+          mergedPrFeatureBug: 0,
+          mergedPrDocs: 0,
+          mergedPrTypo: 0,
+          closedIssueFeatureBug: 0,
+          closedIssueDocs: 0,
+        },
+      ],
+      userScores: [
+        {
+          userId: 'alpha',
+          totalScore: 16,
+          repoScores: [
+            {
+              owner: 'oss2026hnu',
+              repo: 'reposcore-ts',
+              scoreData: [
+                {
+                  userId: 'alpha',
+                  prFeatureBug: 2,
+                  prDocs: 1,
+                  prTypo: 1,
+                  issueFeatureBug: 2,
+                  issueDocs: 1,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = buildUserScoresTxt(data, analyzedAt);
+
+    expect(result).toContain(
+      '=== oss2026hnu/reposcore-ts 오픈소스 기여도 분석 리포트 ===',
+    );
+    expect(result).toContain('분석 일시: 2026-06-04 09:30');
+    expect(result).toContain(
+      '| User  | Issues (Docs/Features) | PR (Docs/Features/Typo) | Score |',
+    );
+    expect(result).toContain(
+      '| ----- | ---------------------: | ----------------------: | ----: |',
+    );
+    expect(result).toContain('alpha');
+    expect(result).toContain('3 (1/2)');
+    expect(result).toContain('4 (1/2/1)');
+    expect(result).toContain('16 |');
+    expect(result).not.toContain('[oss2026hnu/reposcore-ts]');
+  });
+
+  test('미인정 항목이 있으면 추가 제안 섹션을 출력해야 한다', () => {
+    const data: ScoreOutputData = {
+      repoSummaries: [
+        {
+          repoPath: 'oss2026hnu/reposcore-ts',
+          mergedPrFeatureBug: 0,
+          mergedPrDocs: 0,
+          mergedPrTypo: 0,
+          closedIssueFeatureBug: 0,
+          closedIssueDocs: 0,
+        },
+      ],
+      userScores: [
+        {
+          userId: 'beta',
+          totalScore: 6,
+          repoScores: [
+            {
+              owner: 'oss2026hnu',
+              repo: 'reposcore-ts',
+              scoreData: [
+                {
+                  userId: 'beta',
+                  prFeatureBug: 0,
+                  prDocs: 5,
+                  prTypo: 0,
+                  issueFeatureBug: 0,
+                  issueDocs: 0,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = buildUserScoresTxt(data, analyzedAt);
+
+    expect(result).toContain('=== 미인정 항목 및 추가 제안 ===');
+    expect(result).toContain('beta:');
+    expect(result).toContain(
+      '[미인정 항목] 문서/오타 PR 2개 초과(한도 3개) / 이슈 0개 초과(한도 12개)',
+    );
+    expect(result).toContain(
+      '[추가 제안] 기능/버그 PR 1개 추가 시 문서PR 인정 한도 +3',
+    );
+  });
+});


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #224

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [x] `--format txt` 출력 형식을 `reposcore-cs`와 유사한 텍스트 리포트 구조로 변경
- [x] 사용자별 결과를 제목, 분석 일시, ascii 사용 테이블 형태로 출력하도록 개선
- [x] 미인정 항목 및 추가 제안 섹션 출력 로직과 단위 테스트 추가

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
```bash
bun run typecheck
bun test
./node_modules/.bin/eslint src/output.ts tests/output.test.ts
```

### 💬 참고 사항 (선택 사항)