### PR TITLE
Patch 2

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -72,13 +72,8 @@ export const categorizeLabels = (labels: string[]): ContributionLabel => {
   return 'none';
 };
 
-const extractLabelNames = (
-  labels: {nodes: {name: string}[]} | null,
-): string[] => {
-  if (!labels || !labels.nodes) return [];
-
-  return labels.nodes.map(node => node.name).filter(name => Boolean(name));
-};
+const extractLabelNames = (labels: {nodes: {name: string}[]}): string[] =>
+  labels.nodes.map(node => node.name).filter(name => Boolean(name));
 
 const toIssueRecord = (
   raw: RawIssue & {stateReason?: string | null},

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,9 @@ export interface BaseRecord {
    */
   author: {login: string} | null;
   /**
-   * 부착된 라벨 목록. 라벨이 없거나 응답에 포함되지 않으면 `null`입니다.
+   * 부착된 라벨 목록. 라벨이 없으면 빈 배열(`nodes: []`)로 표현합니다.
    */
-  labels: {nodes: {name: string}[]} | null;
+  labels: {nodes: {name: string}[]};
   /**
    * 라벨에서 정규화된 기여 분류. 인식 가능한 라벨이 없으면 `none`입니다.
    */


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #217 

### 변경사항

- `src/types.ts`: `BaseRecord.labels` 타입에서 `| null` 제거 (`{nodes: {name: string}[]} | null` → `{nodes: {name: string}[]}`)
- `src/github-service.ts`: `extractLabelNames`의 불필요한 null 분기 제거 및 arrow function으로 간결화

### 🧪 테스트 방법 (선택 사항)

기존 테스트(`bun test`)가 그대로 통과하는지 확인합니다.

```bash
bun test
bun run typecheck
```

### 💬 참고 사항 (선택 사항)
