### PR TITLE
--claims 옵션으로 열린 이슈 선점 현황 조회 지원

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: all docs synopsis 
+.PHONY: all docs synopsis
 
 PYTHON ?= python3
-JINJA2 ?= jinja2
+JINJA2 ?= python3 -m jinja2cli
 
 DOCS_MD := $(filter-out docs/README.md docs/README-template.md, $(wildcard docs/*.md))
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Options:
   --no-cache            캐시를 무시하고 GitHub API를 새로 호출합니다 (default: true)
   --sort-by <field>     정렬 기준 (score, id) (default: score)
   --sort-order <order>  정렬 방식 (asc, desc) (default: desc)
+  --claims              최근 이슈 선점 현황을 조회합니다 
+  --keywords [items]    이슈 선점 키워드 목록(쉼표 구분) (default: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this)
   -v, --version         Display version number 
   -h, --help            Display this message
 ```

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import {
   supportedFormats,
   type SupportedFormat,
   type RepoSummary,
+  printClaims,
 } from './src/output';
 import {
   sortUserScores,
@@ -17,6 +18,7 @@ import {
   type SupportedSortBy,
   type SupportedSortOrder,
 } from './src/sort';
+import {type ClaimService} from './src/types';
 
 const cli = cac('reposcore-ts');
 cli.version(pkg.version);
@@ -52,6 +54,10 @@ cli
   .option('--sort-order <order>', '정렬 방식 (asc, desc)', {
     default: 'desc',
   })
+  .option('--claims', '최근 이슈 선점 현황을 조회합니다')
+  .option('--keywords <items>', '이슈 선점 키워드 목록(쉼표 구분)', {
+    default: '제가 하겠습니다,진행하겠습니다,할게요,I\'ll take this',
+  })
   .action(
     async (
       repos: string[],
@@ -62,6 +68,8 @@ cli
         outputDir?: string;
         sortBy: string;
         sortOrder: string;
+        claims?: boolean;
+        keywords?: string;
       },
     ) => {
       const token =
@@ -78,6 +86,15 @@ cli
       const sortBy = String(options.sortBy || 'score').toLowerCase();
       const sortOrder = String(options.sortOrder || 'desc').toLowerCase();
       const errors: string[] = [];
+
+      const isClaimsMode = !!options.claims;
+      const claimKeywords = options.keywords
+        ? String(options.keywords)
+            .split(',')
+            .map(k => k.trim())
+            .filter(Boolean)
+        : ['제가 하겠습니다', '진행하겠습니다', '할게요', "I'll take this"];
+
       const parsedRepos: {
         repoPath: string;
         owner: string;
@@ -142,10 +159,30 @@ cli
         process.exit(1);
       }
 
+      const githubService = createGitHubService(token);
+
+      if (isClaimsMode) {
+        for (const {repoPath, owner, repoName} of parsedRepos) {
+          try {
+            // getRecentClaimsData는 github-service.ts에 구현되어야 합니다.
+            const claims = await (githubService as unknown as ClaimService).getRecentClaimsData(
+              owner,
+              repoName,
+              claimKeywords,
+              repoPath,
+            );
+            printClaims(claims);
+          } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error(`오류: '${repoPath}'의 선점 현황을 조회할 수 없습니다. (${msg})`);
+          }
+        }
+        return;
+      }
+
       console.error(`형식: ${formats.join(', ')}`);
       console.error(`저장소: ${repos.join(', ')}`);
 
-      const githubService = createGitHubService(token);
       const repoDataList: RepoData[] = [];
       const repoSummaries: RepoSummary[] = [];
 

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import {
   type SupportedSortBy,
   type SupportedSortOrder,
 } from './src/sort';
-import {type ClaimService} from './src/types';
+import {type FullGitHubService} from './src/types';
 
 const cli = cac('reposcore-ts');
 cli.version(pkg.version);
@@ -55,7 +55,7 @@ cli
     default: 'desc',
   })
   .option('--claims', '최근 이슈 선점 현황을 조회합니다')
-  .option('--keywords <items>', '이슈 선점 키워드 목록(쉼표 구분)', {
+  .option('--keywords [items]', '이슈 선점 키워드 목록(쉼표 구분)', {
     default: '제가 하겠습니다,진행하겠습니다,할게요,I\'ll take this',
   })
   .action(
@@ -88,12 +88,11 @@ cli
       const errors: string[] = [];
 
       const isClaimsMode = !!options.claims;
-      const claimKeywords = options.keywords
-        ? String(options.keywords)
-            .split(',')
-            .map(k => k.trim())
-            .filter(Boolean)
-        : ['제가 하겠습니다', '진행하겠습니다', '할게요', "I'll take this"];
+      const DEFAULT_KEYWORDS = ['제가 하겠습니다', '진행하겠습니다', '할게요', "I'll take this"];
+
+      const claimKeywords = typeof options.keywords === 'string'
+        ? options.keywords.split(',').map(k => k.trim()).filter(Boolean)
+        : DEFAULT_KEYWORDS;
 
       const parsedRepos: {
         repoPath: string;
@@ -159,13 +158,12 @@ cli
         process.exit(1);
       }
 
-      const githubService = createGitHubService(token);
+      const githubService = createGitHubService(token) as FullGitHubService;
 
       if (isClaimsMode) {
         for (const {repoPath, owner, repoName} of parsedRepos) {
           try {
-            // getRecentClaimsData는 github-service.ts에 구현되어야 합니다.
-            const claims = await (githubService as unknown as ClaimService).getRecentClaimsData(
+            const claims = await githubService.getRecentClaimsData(
               owner,
               repoName,
               claimKeywords,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jinja2
+jinja2-cli

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -3,11 +3,32 @@ import {graphql} from '@octokit/graphql';
 import type {
   ContributionLabel,
   DetailedRepoData,
+  ClaimInfo,
+  RepoClaims,
   IssueRecord,
   PRRecord,
 } from './types';
 
 import {loadCache, saveCache} from './cache';
+
+interface ClaimsPageResponse {
+  repository: {
+    issues: {
+      nodes: {
+        number: number;
+        title: string;
+        url: string;
+        comments: {
+          nodes: {
+            body: string;
+            author: {login: string} | null;
+            createdAt: string;
+          }[];
+        };
+      }[];
+    };
+  };
+}
 
 type RawIssue = Omit<IssueRecord, 'category'>;
 type RawPullRequest = Omit<PRRecord, 'category'>;
@@ -447,7 +468,79 @@ export const createGitHubService = (token: string) => {
     return data;
   };
 
+  /**
+   * 열린 이슈와 최근 댓글을 조회하여 선점 키워드가 포함된 이슈를 분류합니다.
+   */
+  const getRecentClaimsData = async (
+    owner: string,
+    repo: string,
+    keywords: string[],
+    repoPath: string,
+  ): Promise<RepoClaims> => {
+    const response = await githubGraphQL<ClaimsPageResponse>(
+      `
+      query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+          issues(first: 50, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+            nodes {
+              number
+              title
+              url
+              comments(last: 10) {
+                nodes {
+                  body
+                  author { login }
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+      `,
+      {owner, repo},
+    );
+
+    const nodes = response.repository.issues.nodes;
+    const claimed: ClaimInfo[] = [];
+    const unclaimed: ClaimInfo[] = [];
+
+    for (const node of nodes) {
+      let matchedClaim: {claimer: string; keyword: string} | null = null;
+      // 최신 댓글부터 확인하여 가장 최근 선점 선언을 찾습니다.
+      const comments = [...node.comments.nodes].reverse();
+
+      for (const comment of comments) {
+        const foundKeyword = keywords.find(k => comment.body.includes(k));
+        if (foundKeyword) {
+          matchedClaim = {
+            claimer: comment.author?.login ?? 'unknown',
+            keyword: foundKeyword,
+          };
+          break;
+        }
+      }
+
+      const info: ClaimInfo = {
+        issueNumber: node.number,
+        title: node.title,
+        url: node.url,
+        claimedBy: matchedClaim?.claimer ?? null,
+        matchedKeyword: matchedClaim?.keyword ?? null,
+      };
+
+      if (matchedClaim) {
+        claimed.push(info);
+      } else {
+        unclaimed.push(info);
+      }
+    }
+
+    return {repoPath, claimed, unclaimed};
+  };
+
   return {
     getDetailedRepoData,
+    getRecentClaimsData,
   };
 };

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -506,7 +506,7 @@ export const createGitHubService = (token: string) => {
     const unclaimed: ClaimInfo[] = [];
 
     for (const node of nodes) {
-      let matchedClaim: {claimer: string; keyword: string} | null = null;
+      let matchedClaim: {claimer: string; keyword: string; createdAt: string} | null = null;
       // 최신 댓글부터 확인하여 가장 최근 선점 선언을 찾습니다.
       const comments = [...node.comments.nodes].reverse();
 
@@ -516,6 +516,7 @@ export const createGitHubService = (token: string) => {
           matchedClaim = {
             claimer: comment.author?.login ?? 'unknown',
             keyword: foundKeyword,
+            createdAt: comment.createdAt,
           };
           break;
         }
@@ -527,6 +528,7 @@ export const createGitHubService = (token: string) => {
         url: node.url,
         claimedBy: matchedClaim?.claimer ?? null,
         matchedKeyword: matchedClaim?.keyword ?? null,
+        claimedAt: matchedClaim?.createdAt ?? null,
       };
 
       if (matchedClaim) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -316,3 +316,34 @@ export const writeOutputFiles = async (
 
   return written;
 };
+
+/**
+ * 선점 현황 데이터를 표준 출력(stdout)에 사람이 읽기 좋은 형태로 출력합니다.
+ *
+ * @param claims 저장소별 선점 및 미선점 이슈 정보
+ */
+export const printClaims = (claims: RepoClaims): void => {
+  console.log(`\n[${claims.repoPath}]`);
+
+  console.log('Claimed Issues');
+  if (claims.claimed.length === 0) {
+    console.log('  (없음)');
+  } else {
+    for (const c of claims.claimed) {
+      console.log(`- #${c.issueNumber} ${c.title}`);
+      console.log(`  URL: ${c.url}`);
+      console.log(`  Claimed by: ${c.claimedBy}`);
+      console.log(`  Matched keyword: ${c.matchedKeyword}`);
+    }
+  }
+
+  console.log('\nUnclaimed Issues');
+  if (claims.unclaimed.length === 0) {
+    console.log('  (없음)');
+  } else {
+    for (const u of claims.unclaimed) {
+      console.log(`- #${u.issueNumber} ${u.title}`);
+      console.log(`  URL: ${u.url}`);
+    }
+  }
+};

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,6 +1,6 @@
 import {mkdir} from 'node:fs/promises';
 import {countByCategory} from './github-service';
-import type {DetailedRepoData} from './types';
+import type {DetailedRepoData, RepoClaims} from './types';
 import type {UserScore} from './score-calculator';
 
 const DEFAULT_OUTPUT_DIR = 'output';
@@ -317,6 +317,57 @@ export const writeOutputFiles = async (
   return written;
 };
 
+/** 상대적인 시간 표시를 위한 헬퍼 함수 */
+const formatRelativeTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  if (diffInSeconds < 60) return '방금 전';
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  if (diffInMinutes < 60) return `${diffInMinutes}분 전`;
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) return `${diffInHours}시간 전`;
+  const diffInDays = Math.floor(diffInHours / 24);
+  return `${diffInDays}일 전`;
+};
+
+/**
+ * 이슈 제목을 기반으로 작업 유형 및 기한(시간)을 결정합니다.
+ * issue-pr-guide.md의 규칙을 따릅니다.
+ */
+const getTaskDeadline = (title: string): {type: string; hours: number} => {
+  const lowerTitle = title.toLowerCase();
+  // 문서 작업 키워드: docs, readme, 문서, 오타, typo 등
+  const isDoc = /docs|readme|문서|오타|typo/i.test(lowerTitle);
+
+  return isDoc
+    ? {type: '📝 문서', hours: 24}
+    : {type: '💻 코드', hours: 48};
+};
+
+/**
+ * 기한 대비 남은 시간 또는 초과 여부를 계산하여 상태 문자열을 반환합니다.
+ */
+const getDeadlineStatus = (
+  claimedAt: string,
+  deadlineHours: number,
+): string => {
+  const start = new Date(claimedAt).getTime();
+  const now = new Date().getTime();
+  const deadline = start + deadlineHours * 60 * 60 * 1000;
+  const remaining = deadline - now;
+
+  if (remaining <= 0) {
+    const overdueHours = Math.floor(Math.abs(remaining) / (1000 * 60 * 60));
+    return `⚠️ 기한 초과 (${overdueHours}시간 경과 - 재선점 가능)`;
+  }
+
+  const h = Math.floor(remaining / (1000 * 60 * 60));
+  const m = Math.floor((remaining % (1000 * 60 * 60)) / (1000 * 60));
+  return `⏳ 남은 시간: ${h}시간 ${m}분`;
+};
+
 /**
  * 선점 현황 데이터를 표준 출력(stdout)에 사람이 읽기 좋은 형태로 출력합니다.
  *
@@ -325,19 +376,25 @@ export const writeOutputFiles = async (
 export const printClaims = (claims: RepoClaims): void => {
   console.log(`\n[${claims.repoPath}]`);
 
-  console.log('Claimed Issues');
+  console.log('선점된 이슈');
   if (claims.claimed.length === 0) {
     console.log('  (없음)');
   } else {
     for (const c of claims.claimed) {
       console.log(`- #${c.issueNumber} ${c.title}`);
       console.log(`  URL: ${c.url}`);
-      console.log(`  Claimed by: ${c.claimedBy}`);
-      console.log(`  Matched keyword: ${c.matchedKeyword}`);
+      if (c.claimedAt) {
+        const {type, hours} = getTaskDeadline(c.title);
+        const status = getDeadlineStatus(c.claimedAt, hours);
+        console.log(`  선점자: ${c.claimedBy}`);
+        console.log(`  상태: ${type} [${hours}시간 기한] | ${status}`);
+      } else {
+        console.log(`  선점자: ${c.claimedBy}`);
+      }
     }
   }
 
-  console.log('\nUnclaimed Issues');
+  console.log('\n미선점 이슈');
   if (claims.unclaimed.length === 0) {
     console.log('  (없음)');
   } else {

--- a/src/output.ts
+++ b/src/output.ts
@@ -317,21 +317,6 @@ export const writeOutputFiles = async (
   return written;
 };
 
-/** 상대적인 시간 표시를 위한 헬퍼 함수 */
-const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
-
-  if (diffInSeconds < 60) return '방금 전';
-  const diffInMinutes = Math.floor(diffInSeconds / 60);
-  if (diffInMinutes < 60) return `${diffInMinutes}분 전`;
-  const diffInHours = Math.floor(diffInMinutes / 60);
-  if (diffInHours < 24) return `${diffInHours}시간 전`;
-  const diffInDays = Math.floor(diffInHours / 24);
-  return `${diffInDays}일 전`;
-};
-
 /**
  * 이슈 제목을 기반으로 작업 유형 및 기한(시간)을 결정합니다.
  * issue-pr-guide.md의 규칙을 따릅니다.

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,3 +83,29 @@ export interface DetailedRepoData {
   /** 수집된 이슈 목록. */
   issues: IssueRecord[];
 }
+
+/** 선점된 이슈 정보 */
+export interface ClaimInfo {
+  issueNumber: number;
+  title: string;
+  url: string;
+  claimedBy: string | null;
+  matchedKeyword: string | null;
+}
+
+/** 저장소별 선점 현황 */
+export interface RepoClaims {
+  repoPath: string;
+  claimed: ClaimInfo[];
+  unclaimed: ClaimInfo[];
+}
+
+/** 선점 현황 조회를 위한 서비스 인터페이스 확장 */
+export interface ClaimService {
+  getRecentClaimsData(
+    owner: string,
+    repoName: string,
+    keywords: string[],
+    repoPath: string,
+  ): Promise<RepoClaims>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface ClaimInfo {
   url: string;
   claimedBy: string | null;
   matchedKeyword: string | null;
+  claimedAt: string | null;
 }
 
 /** 저장소별 선점 현황 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,17 @@ export interface IssueRecord extends BaseRecord {
 }
 
 /**
+ * GitHub API에서 상세 저장소 데이터를 가져오는 핵심 서비스 인터페이스.
+ */
+export interface GitHubServiceCore {
+  getDetailedRepoData(
+    owner: string,
+    repoName: string,
+    useCache: boolean,
+  ): Promise<DetailedRepoData>;
+}
+
+/**
  * 한 저장소에서 수집한 상세 데이터. 점수 계산의 입력으로 사용됩니다.
  */
 export interface DetailedRepoData {
@@ -101,7 +112,9 @@ export interface RepoClaims {
   unclaimed: ClaimInfo[];
 }
 
-/** 선점 현황 조회를 위한 서비스 인터페이스 확장 */
+/**
+ * 선점 현황 조회를 위한 서비스 인터페이스.
+ */
 export interface ClaimService {
   getRecentClaimsData(
     owner: string,
@@ -110,3 +123,9 @@ export interface ClaimService {
     repoPath: string,
   ): Promise<RepoClaims>;
 }
+
+/**
+ * 모든 GitHub 서비스 기능을 포함하는 통합 인터페이스.
+ * `createGitHubService` 함수가 반환해야 하는 타입입니다.
+ */
+export type FullGitHubService = GitHubServiceCore & ClaimService;


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #222 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] --keywords 옵션 추가: 선점 판별을 위한 키워드를 지정할 수 있으며, 값이 없어도 기본 키워드가 작동하도록 선택적 인자로 처리했습니다.
- [ ] --claims 옵션 추가: 활성화 시 점수 계산 대신 이슈 선점 현황을 조회합니다
- [ ] getTaskDeadline: 이슈 제목을 분석하여 **문서 작업(24시간)**과 **코드 작업(48시간)**을 자동으로 분류합니다.
- [ ] getDeadlineStatus: 선점 시점부터 현재까지의 시간을 계산하여 남은 시간(H시간 M분) 또는 기한 초과 상태를 실시간으로 계산해 보여줍니다.

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
bun run index.ts oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts --claims 
위 명령어를 실행하여 테스트

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
