### PR TITLE
sortUserScores 정렬 규칙 테스트 추가

### DIFF
--- a/tests/sort.test.ts
+++ b/tests/sort.test.ts
@@ -1,0 +1,89 @@
+import {describe, expect, test} from 'bun:test';
+
+import {sortUserScores} from '../src/sort';
+import type {UserScore} from '../src/score-calculator';
+
+const createUserScore = (userId: string, totalScore: number): UserScore => ({
+  userId,
+  totalScore,
+  repoScores: [],
+});
+
+describe('sortUserScores', () => {
+  const users: UserScore[] = [
+    createUserScore('kim', 10),
+    createUserScore('lee', 20),
+    createUserScore('park', 10),
+    createUserScore('choi', 30),
+  ];
+
+  test('score 기준 내림차순으로 정렬한다', () => {
+    const result = sortUserScores(users, 'score', 'desc');
+
+    expect(result.map(user => user.userId)).toEqual([
+      'choi',
+      'lee',
+      'kim',
+      'park',
+    ]);
+  });
+
+  test('score 기준 오름차순으로 정렬한다', () => {
+    const result = sortUserScores(users, 'score', 'asc');
+
+    expect(result.map(user => user.userId)).toEqual([
+      'kim',
+      'park',
+      'lee',
+      'choi',
+    ]);
+  });
+
+  test('score 기준 정렬에서 점수가 같으면 userId 오름차순으로 2차 정렬한다', () => {
+    const tiedUsers: UserScore[] = [
+      createUserScore('park', 10),
+      createUserScore('lee', 20),
+      createUserScore('kim', 10),
+    ];
+
+    const result = sortUserScores(tiedUsers, 'score', 'desc');
+
+    expect(result.map(user => user.userId)).toEqual(['lee', 'kim', 'park']);
+  });
+
+  test('id 기준 오름차순으로 정렬한다', () => {
+    const result = sortUserScores(users, 'id', 'asc');
+
+    expect(result.map(user => user.userId)).toEqual([
+      'choi',
+      'kim',
+      'lee',
+      'park',
+    ]);
+  });
+
+  test('id 기준 내림차순으로 정렬한다', () => {
+    const result = sortUserScores(users, 'id', 'desc');
+
+    expect(result.map(user => user.userId)).toEqual([
+      'park',
+      'lee',
+      'kim',
+      'choi',
+    ]);
+  });
+
+  test('원본 배열을 변경하지 않는다', () => {
+    const originalUsers: UserScore[] = [
+      createUserScore('kim', 10),
+      createUserScore('lee', 20),
+      createUserScore('park', 10),
+    ];
+
+    const originalOrder = originalUsers.map(user => user.userId);
+    const result = sortUserScores(originalUsers, 'score', 'desc');
+
+    expect(result.map(user => user.userId)).toEqual(['lee', 'kim', 'park']);
+    expect(originalUsers.map(user => user.userId)).toEqual(originalOrder);
+  });
+});


### PR DESCRIPTION
### ISSUE_ID
Closes #221

### 변경사항
- tests/sort.test.ts 추가
- sortUserScores()의 score/id 기준 정렬 규칙 테스트 추가
- 동점자 처리(userId 오름차순) 및 원본 배열 불변성 테스트 추가

### 🧪 테스트 방법 (선택 사항)
다음 명령어로 테스트를 수행했습니다.
bun test
결과:
score 기준 내림차순 정렬 테스트 통과
score 기준 오름차순 정렬 테스트 통과
score 동률 시 userId 오름차순 정렬 테스트 통과
id 기준 오름차순 정렬 테스트 통과
id 기준 내림차순 정렬 테스트 통과
원본 배열 불변성 테스트 통과

전체 결과:
14 pass
0 fail

### 💬 참고 사항 (선택 사항)
기존 tests/score-calculator.test.ts와 동일한 테스트 디렉토리 구조를 따라 tests/sort.test.ts에 테스트를 추가했습니다.
정렬 규칙 변경 시 회귀(regression)를 방지할 수 있도록 핵심 정렬 동작을 단위 테스트로 고정했습니다.
GitHub API 호출 없이 동작하는 순수 단위 테스트로 작성했습니다.
