### PR TITLE
CLI 표준 사양에 맞춘 로그 출력 스트림(stdout/stderr) 분리 및 일관성 개선

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ cli
   })
   .option('--claims', '최근 이슈 선점 현황을 조회합니다')
   .option('--keywords [items]', '이슈 선점 키워드 목록(쉼표 구분)', {
-    default: '제가 하겠습니다,진행하겠습니다,할게요,I\'ll take this',
+    default: "제가 하겠습니다,진행하겠습니다,할게요,I'll take this",
   })
   .action(
     async (
@@ -88,11 +88,20 @@ cli
       const errors: string[] = [];
 
       const isClaimsMode = !!options.claims;
-      const DEFAULT_KEYWORDS = ['제가 하겠습니다', '진행하겠습니다', '할게요', "I'll take this"];
+      const DEFAULT_KEYWORDS = [
+        '제가 하겠습니다',
+        '진행하겠습니다',
+        '할게요',
+        "I'll take this",
+      ];
 
-      const claimKeywords = typeof options.keywords === 'string'
-        ? options.keywords.split(',').map(k => k.trim()).filter(Boolean)
-        : DEFAULT_KEYWORDS;
+      const claimKeywords =
+        typeof options.keywords === 'string'
+          ? options.keywords
+              .split(',')
+              .map(k => k.trim())
+              .filter(Boolean)
+          : DEFAULT_KEYWORDS;
 
       const parsedRepos: {
         repoPath: string;
@@ -172,14 +181,16 @@ cli
             printClaims(claims);
           } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : String(error);
-            console.error(`오류: '${repoPath}'의 선점 현황을 조회할 수 없습니다. (${msg})`);
+            console.error(
+              `오류: '${repoPath}'의 선점 현황을 조회할 수 없습니다. (${msg})`,
+            );
           }
         }
         return;
       }
 
-      console.error(`형식: ${formats.join(', ')}`);
-      console.error(`저장소: ${repos.join(', ')}`);
+      console.log(`형식: ${formats.join(', ')}`);
+      console.log(`저장소: ${repos.join(', ')}`);
 
       const repoDataList: RepoData[] = [];
       const repoSummaries: RepoSummary[] = [];
@@ -218,12 +229,12 @@ cli
             outputDir,
             subDir,
           );
-          console.error(`[${repoPath}] CSV 저장: ${written.csv}`);
+          console.log(`[${repoPath}] CSV 저장: ${written.csv}`);
           if (written.txt) {
-            console.error(`[${repoPath}] TXT 저장: ${written.txt}`);
+            console.log(`[${repoPath}] TXT 저장: ${written.txt}`);
           }
           if (written.html) {
-            console.error(`[${repoPath}] HTML 저장: ${written.html}`);
+            console.log(`[${repoPath}] HTML 저장: ${written.html}`);
           }
         } catch (error: unknown) {
           const errorMessage =
@@ -249,12 +260,12 @@ cli
         },
         outputDir,
       );
-      console.error(`[합산] CSV 저장: ${written.csv}`);
+      console.log(`[합산] CSV 저장: ${written.csv}`);
       if (written.txt) {
-        console.error(`[합산] TXT 저장: ${written.txt}`);
+        console.log(`[합산] TXT 저장: ${written.txt}`);
       }
       if (written.html) {
-        console.error(`[합산] HTML 저장: ${written.html}`);
+        console.log(`[합산] HTML 저장: ${written.html}`);
       }
     },
   );

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -501,7 +501,11 @@ export const createGitHubService = (token: string) => {
     const unclaimed: ClaimInfo[] = [];
 
     for (const node of nodes) {
-      let matchedClaim: {claimer: string; keyword: string; createdAt: string} | null = null;
+      let matchedClaim: {
+        claimer: string;
+        keyword: string;
+        createdAt: string;
+      } | null = null;
       // 최신 댓글부터 확인하여 가장 최근 선점 선언을 찾습니다.
       const comments = [...node.comments.nodes].reverse();
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -326,9 +326,7 @@ const getTaskDeadline = (title: string): {type: string; hours: number} => {
   // 문서 작업 키워드: docs, readme, 문서, 오타, typo 등
   const isDoc = /docs|readme|문서|오타|typo/i.test(lowerTitle);
 
-  return isDoc
-    ? {type: '📝 문서', hours: 24}
-    : {type: '💻 코드', hours: 48};
+  return isDoc ? {type: '📝 문서', hours: 24} : {type: '💻 코드', hours: 48};
 };
 
 /**


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/237

### 변경사항
- [x] index.ts의 정상 실행 로그를 console.error에서 console.log로 변경

### 🧪 테스트 방법 (선택 사항)
bun run index.ts oss2026hnu/reposcore-ts --token <TOKEN>

### 💬 참고 사항 (선택 사항)
bun run fix를 실행하여 index.ts, src/github-service.ts, src/output.ts의 포맷을 프로젝트 규칙에 맞게 정리했습니다.
