### PR TITLE
PAGE_SIZE를 CLI 옵션·환경변수로 주입 가능하게 변경 (#242)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Options:
   --sort-order <order>  정렬 방식 (asc, desc) (default: desc)
   --claims              최근 이슈 선점 현황을 조회합니다 
   --keywords [items]    이슈 선점 키워드 목록(쉼표 구분) (default: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this)
+  --page-size <number>  한 번에 가져올 항목 수 (1~100) (default: $PAGE_SIZE)
   -v, --version         Display version number 
   -h, --help            Display this message
 ```

--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,9 @@ cli
   .option('--keywords [items]', '이슈 선점 키워드 목록(쉼표 구분)', {
     default: "제가 하겠습니다,진행하겠습니다,할게요,I'll take this",
   })
+  .option('--page-size <number>', '한 번에 가져올 항목 수 (1~100)', {
+    default: '$PAGE_SIZE',
+  })
   .action(
     async (
       repos: string[],
@@ -70,6 +73,7 @@ cli
         sortOrder: string;
         claims?: boolean;
         keywords?: string;
+        pageSize?: number | string;
       },
     ) => {
       const token =
@@ -85,6 +89,13 @@ cli
       const outputDir = options.outputDir || 'output';
       const sortBy = String(options.sortBy || 'score').toLowerCase();
       const sortOrder = String(options.sortOrder || 'desc').toLowerCase();
+
+      const rawPageSize =
+        options.pageSize === '$PAGE_SIZE'
+          ? Bun.env.PAGE_SIZE ?? 100
+          : options.pageSize;
+      const pageSize = Number(rawPageSize);
+
       const errors: string[] = [];
 
       const isClaimsMode = !!options.claims;
@@ -137,6 +148,12 @@ cli
         );
       }
 
+      if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+        errors.push(
+          `오류: --page-size 값은 1 이상 100 이하의 정수여야 합니다. (입력값: ${options.pageSize})`,
+        );
+      }
+
       if (repos.length === 0) {
         errors.push(
           '오류: 최소 하나 이상의 저장소(owner/repo)를 입력해야 합니다.',
@@ -167,7 +184,7 @@ cli
         process.exit(1);
       }
 
-      const githubService = createGitHubService(token) as FullGitHubService;
+      const githubService = createGitHubService(token, pageSize) as FullGitHubService;
 
       if (isClaimsMode) {
         for (const {repoPath, owner, repoName} of parsedRepos) {

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -70,8 +70,6 @@ interface PullRequestSearchResponse {
   };
 }
 
-const PAGE_SIZE = 100;
-
 export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
   if (key === 'feat' || key === 'feature' || key === 'enhancement')
@@ -170,7 +168,7 @@ export const countByCategory = (
   return counts;
 };
 
-export const createGitHubService = (token: string) => {
+export const createGitHubService = (token: string, pageSize = 100) => {
   const githubGraphQL = graphql.defaults({
     headers: {
       authorization: `token ${token}`,
@@ -220,7 +218,7 @@ export const createGitHubService = (token: string) => {
             }
           }
           `,
-          {owner, repo, pageSize: PAGE_SIZE, cursor},
+          {owner, repo, pageSize, cursor},
         );
 
       const connection: IssuePageResponse['repository']['issues'] =
@@ -284,7 +282,7 @@ export const createGitHubService = (token: string) => {
             }
           }
           `,
-          {owner, repo, pageSize: PAGE_SIZE, cursor},
+          {owner, repo, pageSize, cursor},
         );
 
       const connection: PullRequestPageResponse['repository']['pullRequests'] =
@@ -345,7 +343,7 @@ export const createGitHubService = (token: string) => {
           `,
           {
             searchQuery: `repo:${owner}/${repo} is:issue updated:>=${since}`,
-            pageSize: PAGE_SIZE,
+            pageSize,
             cursor,
           },
         );
@@ -410,7 +408,7 @@ export const createGitHubService = (token: string) => {
           `,
           {
             searchQuery: `repo:${owner}/${repo} is:pr is:merged updated:>=${since}`,
-            pageSize: PAGE_SIZE,
+            pageSize,
             cursor,
           },
         );


### PR DESCRIPTION
### ISSUE_ID
Closes #242

### 변경사항
- [x] `github-service.ts`: 하드코딩 상수 `const PAGE_SIZE = 100` 제거 → `createGitHubService(token, pageSize = 100)`로 인자 주입 방식으로 변경 (페이지네이션 4개 함수가 클로저로 `pageSize` 참조)
- [x] `index.ts`: CLI 옵션 `--page-size <number>` 추가 + 1~100 정수 범위 검증 + 서비스 생성 시 주입
- [x] 환경변수 `PAGE_SIZE` 폴백 지원 (우선순위: CLI 옵션 > 환경변수 > 기본값 100) 및 `make synopsis`로 README 갱신

### 🧪 테스트 방법 (선택 사항)
- `--page-size 2` 정상 동작 확인 (수집 결과 수는 동일, 요청 왕복만 증가)
- `--page-size 200` → "1 이상 100 이하" 에러로 거부 확인
- `PAGE_SIZE=999 bun run index.ts ...` → 동일 에러로 거부 (환경변수가 검증까지 흘러감을 확인)
- `PAGE_SIZE=999 ... --page-size 50` → 정상 실행 (CLI가 환경변수를 덮어쓰는 우선순위 확인)
- `bun run typecheck` 통과 / `bun test` 16개 전체 통과

### 💬 참고 사항 (선택 사항)
- GitHub GraphQL의 connection `first` 인자는 최대 100이라, `--page-size`는 100 이하로 "줄이는" 용도로만 유효합니다(타임아웃 방어, 페이지네이션 로직 로컬 테스트). 검증 상한을 100으로 둔 이유입니다.
- 도움말의 `(default: $PAGE_SIZE)` 표기는 기존 `--token`의 `$GITHUB_TOKEN` 센티넬 방식과 통일한 것입니다. 환경변수 설정 여부와 무관하게 README가 안정적으로 생성되도록 하기 위함입니다.
