### PR TITLE
github-service.ts, cache.ts, index.ts에 TSDoc 주석 보강

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,11 @@ import {type FullGitHubService} from './src/types';
 const cli = cac('reposcore-ts');
 cli.version(pkg.version);
 
+/**
+ * 저장소 경로 문자열을 소유자와 저장소 이름으로 분리합니다.
+ * @param repoPath owner/repo 형식의 저장소 경로
+ * @returns 저장소 소유자와 이름 정보, 형식이 올바르지 않으면 null
+ */
 function parseRepoPath(repoPath: string) {
   const parts = repoPath.split('/');
 
@@ -72,6 +77,7 @@ cli
         keywords?: string;
       },
     ) => {
+      // CLI 옵션값을 내부에서 사용할 형태로 정규화합니다.
       const token =
         options.token === '$GITHUB_TOKEN'
           ? Bun.env.GITHUB_TOKEN || ''
@@ -88,6 +94,7 @@ cli
       const errors: string[] = [];
 
       const isClaimsMode = !!options.claims;
+      // 이슈 선점 여부를 판단하기 위한 기본 키워드 목록입니다.
       const DEFAULT_KEYWORDS = [
         '제가 하겠습니다',
         '진행하겠습니다',
@@ -109,6 +116,7 @@ cli
         repoName: string;
       }[] = [];
 
+      // CLI 실행에 필요한 옵션과 입력값을 검증합니다.
       if (!token) {
         errors.push(
           '오류: GitHub 토큰이 필요합니다. --token 옵션 또는 GITHUB_TOKEN 환경 변수를 설정하세요.',
@@ -143,6 +151,7 @@ cli
         );
       }
 
+      // 입력받은 저장소 경로를 owner/repo 형식으로 파싱합니다.
       for (const repoPath of repos) {
         const parsedRepo = parseRepoPath(repoPath);
 
@@ -158,6 +167,7 @@ cli
         });
       }
 
+      // 검증 중 발견된 오류를 출력하고 실행을 중단합니다.
       if (errors.length > 0) {
         for (const error of errors) {
           console.error(error);
@@ -167,8 +177,10 @@ cli
         process.exit(1);
       }
 
+      // GitHub API 호출을 위한 서비스 객체를 생성합니다.
       const githubService = createGitHubService(token) as FullGitHubService;
 
+      // --claims 옵션이 있으면 점수 계산 대신 이슈 선점 현황만 조회합니다.
       if (isClaimsMode) {
         for (const {repoPath, owner, repoName} of parsedRepos) {
           try {
@@ -195,6 +207,7 @@ cli
       const repoDataList: RepoData[] = [];
       const repoSummaries: RepoSummary[] = [];
 
+      // 저장소별 GitHub 데이터를 수집하고 개별 결과 파일을 생성합니다.
       for (const {repoPath, owner, repoName} of parsedRepos) {
         try {
           const detailed = await githubService.getDetailedRepoData(
@@ -203,6 +216,7 @@ cli
             useCache,
           );
 
+          // 수집한 데이터를 바탕으로 저장소별 점수와 요약 정보를 계산합니다.
           const repoData = ScoreCalculator.calculateRepoData(
             detailed,
             owner,
@@ -219,6 +233,7 @@ cli
             sortOrder as SupportedSortOrder,
           );
 
+          // 저장소별 사용자 점수와 요약 정보를 파일로 출력합니다.
           const subDir = `${owner}-${repoName}`;
           const written = await writeOutputFiles(
             formats as SupportedFormat[],
@@ -246,12 +261,14 @@ cli
         }
       }
 
+      // 모든 저장소 데이터를 합산하여 최종 사용자 점수를 계산합니다.
       const userScores = sortUserScores(
         ScoreCalculator.calculateUserScores(repoDataList),
         sortBy as SupportedSortBy,
         sortOrder as SupportedSortOrder,
       );
 
+      // 합산된 사용자 점수와 저장소 요약 정보를 파일로 출력합니다.
       const written = await writeOutputFiles(
         formats as SupportedFormat[],
         {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,14 +1,32 @@
 const CACHE_DIR = '.cache';
 
+/**
+ * 저장소별 분석 결과를 저장하는 캐시 데이터 구조입니다.
+ * @typeParam T 캐시에 저장할 분석 데이터 타입
+ */
 export interface RepoCache<T> {
   repository: string;
   lastAnalyzedAt: string;
   data: T;
 }
 
+/**
+ * 저장소별 캐시 파일 경로를 생성합니다.
+ * @param owner 저장소 소유자
+ * @param repo 저장소 이름
+ * @returns 저장소 캐시 파일 경로
+ */
 const getCacheFilePath = (owner: string, repo: string): string =>
   `${CACHE_DIR}/${owner}_${repo}/cache.json`;
 
+/**
+ * 저장소의 캐시 파일을 읽어 기존 분석 결과를 불러옵니다.
+ * 캐시를 사용하지 않도록 설정했거나 캐시 파일이 없거나 손상된 경우 null을 반환합니다.
+ * @param owner 저장소 소유자
+ * @param repo 저장소 이름
+ * @param noCache 캐시 사용을 건너뛸지 여부
+ * @returns 저장소 캐시 데이터 또는 null
+ */
 export const loadCache = async <T>(
   owner: string,
   repo: string,
@@ -37,6 +55,14 @@ export const loadCache = async <T>(
   }
 };
 
+/**
+ * 저장소 분석 결과를 캐시 파일로 저장합니다.
+ * @param owner 저장소 소유자
+ * @param repo 저장소 이름
+ * @param data 캐시에 저장할 분석 결과 데이터
+ * @param analyzedAt 분석 기준 시각
+ * @returns 반환값이 없습니다.
+ */
 export const saveCache = async <T>(
   owner: string,
   repo: string,

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -72,6 +72,11 @@ interface PullRequestSearchResponse {
 
 const PAGE_SIZE = 100;
 
+/**
+ * GitHub 라벨명을 내부 기여 카테고리로 정규화합니다.
+ * @param label 정규화할 GitHub 라벨명
+ * @returns 정규화된 기여 카테고리
+ */
 export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
   if (key === 'feat' || key === 'feature' || key === 'enhancement')
@@ -82,6 +87,11 @@ export const normalizeLabel = (label: string): ContributionLabel => {
   return 'none';
 };
 
+/**
+ * 여러 라벨 중 기여 카테고리에 해당하는 첫 번째 라벨을 찾습니다.
+ * @param labels GitHub 라벨명 목록
+ * @returns 분류된 기여 카테고리
+ */
 export const categorizeLabels = (labels: string[]): ContributionLabel => {
   for (const label of labels) {
     const category = normalizeLabel(label);
@@ -93,9 +103,19 @@ export const categorizeLabels = (labels: string[]): ContributionLabel => {
   return 'none';
 };
 
+/**
+ * GitHub 라벨 노드 목록에서 라벨명만 추출합니다.
+ * @param labels GitHub GraphQL 응답의 라벨 노드 목록
+ * @returns 라벨명 문자열 배열
+ */
 const extractLabelNames = (labels: {nodes: {name: string}[]}): string[] =>
   labels.nodes.map(node => node.name).filter(name => Boolean(name));
 
+/**
+ * GitHub Issue 원본 데이터를 내부 IssueRecord 형식으로 변환합니다.
+ * @param raw GitHub GraphQL 응답에서 가져온 Issue 데이터
+ * @returns 내부에서 사용하는 IssueRecord 객체
+ */
 const toIssueRecord = (
   raw: RawIssue & {stateReason?: string | null},
 ): IssueRecord => {
@@ -112,6 +132,11 @@ const toIssueRecord = (
   };
 };
 
+/**
+ * GitHub Pull Request 원본 데이터를 내부 PRRecord 형식으로 변환합니다.
+ * @param raw GitHub GraphQL 응답에서 가져온 Pull Request 데이터
+ * @returns 내부에서 사용하는 PRRecord 객체
+ */
 const toPrRecord = (raw: RawPullRequest): PRRecord => {
   return {
     number: raw.number,
@@ -127,6 +152,12 @@ const toPrRecord = (raw: RawPullRequest): PRRecord => {
   };
 };
 
+/**
+ * 번호를 기준으로 기존 캐시 데이터와 새로 조회한 데이터를 병합합니다.
+ * @param cachedItems 캐시에 저장되어 있던 기존 항목 목록
+ * @param updatedItems 새로 조회한 최신 항목 목록
+ * @returns 번호 기준으로 병합된 항목 목록
+ */
 const mergeByNumber = <T extends {number: number}>(
   cachedItems: T[],
   updatedItems: T[],
@@ -144,6 +175,9 @@ const mergeByNumber = <T extends {number: number}>(
   return [...itemMap.values()].sort((a, b) => b.number - a.number);
 };
 
+/**
+ * 기여 카테고리별 개수를 나타내는 객체입니다.
+ */
 export interface CategoryCounts {
   feature: number;
   bug: number;
@@ -152,6 +186,11 @@ export interface CategoryCounts {
   none: number;
 }
 
+/**
+ * 기여 기록 목록을 카테고리별로 집계합니다.
+ * @param records 카테고리 정보가 포함된 기여 기록 목록
+ * @returns 카테고리별 개수
+ */
 export const countByCategory = (
   records: ReadonlyArray<{category: ContributionLabel}>,
 ): CategoryCounts => {
@@ -170,6 +209,11 @@ export const countByCategory = (
   return counts;
 };
 
+/**
+ * GitHub GraphQL API를 사용하는 서비스 객체를 생성합니다.
+ * @param token GitHub Personal Access Token
+ * @returns 저장소 상세 데이터와 이슈 선점 현황을 조회하는 서비스 객체
+ */
 export const createGitHubService = (token: string) => {
   const githubGraphQL = graphql.defaults({
     headers: {
@@ -177,6 +221,13 @@ export const createGitHubService = (token: string) => {
     },
   });
 
+  /**
+   * 저장소의 유효한 이슈를 모두 조회합니다.
+   * OPEN 상태이거나 완료 처리된 이슈만 수집합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @returns 유효한 이슈 목록
+   */
   const getAllValidIssues = async (
     owner: string,
     repo: string,
@@ -240,6 +291,12 @@ export const createGitHubService = (token: string) => {
     return issues;
   };
 
+  /**
+   * 저장소의 병합된 Pull Request를 모두 조회합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @returns 병합된 Pull Request 목록
+   */
   const getAllMergedPullRequests = async (
     owner: string,
     repo: string,
@@ -299,6 +356,14 @@ export const createGitHubService = (token: string) => {
     return prs;
   };
 
+  /**
+   * 지정한 시점 이후 변경된 유효 이슈를 조회합니다.
+   * OPEN 상태이거나 완료 처리된 이슈만 수집합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @param since 변경 내역을 조회할 기준 시각
+   * @returns 기준 시각 이후 변경된 유효 이슈 목록
+   */
   const getUpdatedValidIssues = async (
     owner: string,
     repo: string,
@@ -364,6 +429,13 @@ export const createGitHubService = (token: string) => {
     return issues;
   };
 
+  /**
+   * 지정한 시점 이후 변경된 병합 Pull Request를 조회합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @param since 변경 내역을 조회할 기준 시각
+   * @returns 기준 시각 이후 변경된 병합 Pull Request 목록
+   */
   const getUpdatedMergedPullRequests = async (
     owner: string,
     repo: string,
@@ -424,6 +496,15 @@ export const createGitHubService = (token: string) => {
     return prs;
   };
 
+  /**
+   * 저장소의 이슈와 병합된 Pull Request 상세 데이터를 조회합니다.
+   * 캐시가 있으면 마지막 분석 시점 이후의 변경분만 조회해 병합하고,
+   * 캐시가 없으면 전체 데이터를 새로 수집합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @param useCache 캐시 사용 여부
+   * @returns 저장소의 상세 기여 데이터
+   */
   const getDetailedRepoData = async (
     owner: string,
     repo: string,
@@ -465,6 +546,11 @@ export const createGitHubService = (token: string) => {
 
   /**
    * 열린 이슈와 최근 댓글을 조회하여 선점 키워드가 포함된 이슈를 분류합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @param keywords 선점 여부를 판단할 키워드 목록
+   * @param repoPath 출력에 사용할 저장소 경로
+   * @returns 선점된 이슈와 선점되지 않은 이슈 목록
    */
   const getRecentClaimsData = async (
     owner: string,


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/241

### 변경사항
- [x] github-service.ts 주요 함수에 TSDoc 주석 추가
- [x] cache.ts의 RepoCache, loadCache, saveCache에 TSDoc 주석 추가
- [x] index.ts에 실행 흐름을 이해하기 위한 인라인 주석 추가 및 parseRepoPath 함수에 TSDoc 주석 추가

### 🧪 테스트 방법 (선택 사항)

### 💬 참고 사항 (선택 사항)
- 코드 로직 변경 없이 주석(TSDoc 및 인라인 주석)만 추가하였습니다.