### PR TITLE
캐시 동기화 기준 시점 주입 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   --format <format>     출력 형식 (csv, txt, html) (default: csv)
   --output-dir <path>   결과 파일을 저장할 디렉터리 (default: output)
   --no-cache            캐시를 무시하고 GitHub API를 새로 호출합니다 (default: true)
+  --since <since>       캐시 이후 증분 수집 기준 시점 ISO8601 
   --sort-by <field>     정렬 기준 (score, id) (default: score)
   --sort-order <order>  정렬 방식 (asc, desc) (default: desc)
   --claims              최근 이슈 선점 현황을 조회합니다 

--- a/index.ts
+++ b/index.ts
@@ -48,6 +48,7 @@ cli
     default: 'output',
   })
   .option('--no-cache', '캐시를 무시하고 GitHub API를 새로 호출합니다')
+  .option('--since <since>', '캐시 이후 증분 수집 기준 시점 ISO8601')
   .option('--sort-by <field>', '정렬 기준 (score, id)', {
     default: 'score',
   })
@@ -69,6 +70,7 @@ cli
         format: string;
         cache: boolean;
         outputDir?: string;
+        since?: string;
         sortBy: string;
         sortOrder: string;
         claims?: boolean;
@@ -85,14 +87,15 @@ cli
         .split(',')
         .map(format => format.trim())
         .filter(Boolean);
-      const useCache = options.cache; // --no-cache 전달 시 false
+      const useCache = options.cache;
       const outputDir = options.outputDir || 'output';
+      const since = options.since;
       const sortBy = String(options.sortBy || 'score').toLowerCase();
       const sortOrder = String(options.sortOrder || 'desc').toLowerCase();
 
       const rawPageSize =
         options.pageSize === '$PAGE_SIZE'
-          ? Bun.env.PAGE_SIZE ?? 100
+          ? (Bun.env.PAGE_SIZE ?? 100)
           : options.pageSize;
       const pageSize = Number(rawPageSize);
 
@@ -184,7 +187,10 @@ cli
         process.exit(1);
       }
 
-      const githubService = createGitHubService(token, pageSize) as FullGitHubService;
+      const githubService = createGitHubService(
+        token,
+        pageSize,
+      ) as FullGitHubService;
 
       if (isClaimsMode) {
         for (const {repoPath, owner, repoName} of parsedRepos) {
@@ -218,6 +224,7 @@ cli
             owner,
             repoName,
             useCache,
+            {since},
           );
 
           const repoData = ScoreCalculator.calculateRepoData(

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -70,6 +70,10 @@ interface PullRequestSearchResponse {
   };
 }
 
+interface GetDetailedRepoDataOptions {
+  since?: string;
+}
+
 export const normalizeLabel = (label: string): ContributionLabel => {
   const key = label.toLowerCase().replace(/[-_\s]/g, '');
   if (key === 'feat' || key === 'feature' || key === 'enhancement')
@@ -426,6 +430,7 @@ export const createGitHubService = (token: string, pageSize = 100) => {
     owner: string,
     repo: string,
     useCache = true,
+    options?: GetDetailedRepoDataOptions,
   ): Promise<DetailedRepoData> => {
     const analysisStartedAt = new Date().toISOString();
     const cached = await loadCache<DetailedRepoData>(owner, repo, !useCache);
@@ -446,9 +451,11 @@ export const createGitHubService = (token: string, pageSize = 100) => {
       return data;
     }
 
+    const since = options?.since ?? cached.lastAnalyzedAt;
+
     const [updatedIssues, updatedPrs] = await Promise.all([
-      getUpdatedValidIssues(owner, repo, cached.lastAnalyzedAt),
-      getUpdatedMergedPullRequests(owner, repo, cached.lastAnalyzedAt),
+      getUpdatedValidIssues(owner, repo, since),
+      getUpdatedMergedPullRequests(owner, repo, since),
     ]);
 
     const data: DetailedRepoData = {
@@ -504,7 +511,6 @@ export const createGitHubService = (token: string, pageSize = 100) => {
         keyword: string;
         createdAt: string;
       } | null = null;
-      // 최신 댓글부터 확인하여 가장 최근 선점 선언을 찾습니다.
       const comments = [...node.comments.nodes].reverse();
 
       for (const comment of comments) {

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -219,7 +219,7 @@ export const countByCategory = (
  * @param token GitHub Personal Access Token
  * @returns 저장소 상세 데이터와 이슈 선점 현황을 조회하는 서비스 객체
  */
-export const createGitHubService = (token: string) => {
+export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
   const githubGraphQL = graphql.defaults({
     headers: {
       authorization: `token ${token}`,
@@ -276,7 +276,7 @@ export const createGitHubService = (token: string) => {
             }
           }
           `,
-          {owner, repo, pageSize: PAGE_SIZE, cursor},
+          {owner, repo, pageSize, cursor},
         );
 
       const connection: IssuePageResponse['repository']['issues'] =
@@ -346,7 +346,7 @@ export const createGitHubService = (token: string) => {
             }
           }
           `,
-          {owner, repo, pageSize: PAGE_SIZE, cursor},
+          {owner, repo, pageSize, cursor},
         );
 
       const connection: PullRequestPageResponse['repository']['pullRequests'] =
@@ -415,7 +415,7 @@ export const createGitHubService = (token: string) => {
           `,
           {
             searchQuery: `repo:${owner}/${repo} is:issue updated:>=${since}`,
-            pageSize: PAGE_SIZE,
+            pageSize,
             cursor,
           },
         );
@@ -487,7 +487,7 @@ export const createGitHubService = (token: string) => {
           `,
           {
             searchQuery: `repo:${owner}/${repo} is:pr is:merged updated:>=${since}`,
-            pageSize: PAGE_SIZE,
+            pageSize,
             cursor,
           },
         );
@@ -572,8 +572,9 @@ export const createGitHubService = (token: string) => {
     let hasNextPage = true;
 
     while (hasNextPage) {
-      const response: ClaimsPageResponse = await githubGraphQL<ClaimsPageResponse>(
-        `
+      const response: ClaimsPageResponse =
+        await githubGraphQL<ClaimsPageResponse>(
+          `
         query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
           repository(owner: $owner, name: $repo) {
             issues(first: $pageSize, after: $cursor, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
@@ -597,8 +598,8 @@ export const createGitHubService = (token: string) => {
           }
         }
         `,
-        {owner, repo, pageSize: PAGE_SIZE, cursor},
-      );
+          {owner, repo, pageSize, cursor},
+        );
 
       const connection = response.repository.issues;
       const nodes = connection.nodes;
@@ -609,7 +610,7 @@ export const createGitHubService = (token: string) => {
           keyword: string;
           createdAt: string;
         } | null = null;
-        
+
         const comments = [...node.comments.nodes].reverse();
 
         for (const comment of comments) {
@@ -631,7 +632,7 @@ export const createGitHubService = (token: string) => {
           claimedBy: matchedClaim?.claimer ?? null,
           matchedKeyword: matchedClaim?.keyword ?? null,
           claimedAt: matchedClaim?.createdAt ?? null,
-      };
+        };
 
         if (matchedClaim) {
           claimed.push(info);

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,9 @@ export interface GitHubServiceCore {
     owner: string,
     repoName: string,
     useCache: boolean,
+    options?: {
+      since?: string;
+    },
   ): Promise<DetailedRepoData>;
 }
 


### PR DESCRIPTION
### ISSUE_ID
Closes #230

### 변경사항
1. CLI에 --since <ISO8601> 옵션 추가
2. getDetailedRepoData()가 외부에서 since 값을 주입받을 수 있도록 확장
3. --since가 제공된 경우 cached.lastAnalyzedAt 대신 해당 값을 기준으로 증분 수집 및 캐시 병합을 수행하도록 변경

### 🧪 테스트 방법 (선택 사항)
bun run typecheck 으로 타입 검사 통과 확인
bun run index.ts oss2026hnu/reposcore-ts --since 2026-01-01T00:00:00Z 으로 --since 옵션 전달 시 정상 실행 확인
bun run index.ts oss2026hnu/reposcore-ts 으로 기존 캐시 기반 동작이 유지되는지 확인

### 💬 참고 사항 (선택 사항)
기존 동작과의 호환성을 유지하기 위해 --since 옵션은 선택 사항으로 구현했습니다.
--since가 제공되지 않은 경우 기존과 동일하게 cached.lastAnalyzedAt을 기준으로 증분 수집을 수행합니다.
