### PR TITLE
github-servis.ts에 선점 키워드 매칭이 댓글 변형 감지하도록 수정

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -565,8 +565,9 @@ export const createGitHubService = (token: string) => {
     let hasNextPage = true;
 
     while (hasNextPage) {
-      const response: ClaimsPageResponse = await githubGraphQL<ClaimsPageResponse>(
-        `
+      const response: ClaimsPageResponse =
+        await githubGraphQL<ClaimsPageResponse>(
+          `
         query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
           repository(owner: $owner, name: $repo) {
             issues(first: $pageSize, after: $cursor, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
@@ -590,8 +591,8 @@ export const createGitHubService = (token: string) => {
           }
         }
         `,
-        {owner, repo, pageSize: PAGE_SIZE, cursor},
-      );
+          {owner, repo, pageSize: PAGE_SIZE, cursor},
+        );
 
       const connection = response.repository.issues;
       const nodes = connection.nodes;
@@ -602,11 +603,19 @@ export const createGitHubService = (token: string) => {
           keyword: string;
           createdAt: string;
         } | null = null;
-        
+
         const comments = [...node.comments.nodes].reverse();
 
+        const normalize = (text: string): string =>
+          text.replace(/\s+/g, '').toLowerCase();
+
         for (const comment of comments) {
-          const foundKeyword = keywords.find(k => comment.body.includes(k));
+          const normalizedBody = normalize(comment.body);
+
+          const foundKeyword = keywords.find(keyword =>
+            normalizedBody.includes(normalize(keyword)),
+          );
+
           if (foundKeyword) {
             matchedClaim = {
               claimer: comment.author?.login ?? 'unknown',
@@ -624,7 +633,7 @@ export const createGitHubService = (token: string) => {
           claimedBy: matchedClaim?.claimer ?? null,
           matchedKeyword: matchedClaim?.keyword ?? null,
           claimedAt: matchedClaim?.createdAt ?? null,
-      };
+        };
 
         if (matchedClaim) {
           claimed.push(info);


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/247

### 변경사항
- [x] 댓글 본문과 선점 키워드를 공백 제거 및 소문자 변환하여 정규화하는 함수 추가
- [x] 띄어쓰기 및 대소문자 변형(제가하겠습니다, 제가 하겠습니다, i'll take this 등)도 선점으로 인식하도록 개선


### 🧪 테스트 방법 (선택 사항)
- 선점한 이슈의 기존 댓글을 삭제한 후 제가하겠습니다, I'LL TAKE THIS 등  댓글 작성
- bun run index.ts oss2026hnu/reposcore-ts --claims 실행
- 해당 이슈가 "선점된 이슈"로 정상 분류되는 것을 확인

### 💬 참고 사항 (선택 사항)
- bun run fix를 실행하여 프로젝트 규칙에 맞게 정리했습니다.