### PR TITLE
fix: --claims에서 연결된 열린 PR 있으면 재선점 가능 대신 PR 생성됨으로 표시

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -31,6 +31,21 @@ interface ClaimsPageResponse {
   };
 }
 
+interface OpenPrNode {
+  number: number;
+  url: string;
+  body: string | null;
+}
+
+interface OpenPrPageResponse {
+  repository: {
+    pullRequests: {
+      nodes: OpenPrNode[];
+      pageInfo: PageInfo;
+    };
+  };
+}
+
 type RawIssue = Omit<IssueRecord, 'category'>;
 type RawPullRequest = Omit<PRRecord, 'category'>;
 
@@ -566,6 +581,51 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     keywords: string[],
     repoPath: string,
   ): Promise<RepoClaims> => {
+    const issueToOpenPr = new Map<number, {number: number; url: string}>();
+    let prCursor: string | null = null;
+    let prHasNextPage = true;
+
+    while (prHasNextPage) {
+      const prResponse: OpenPrPageResponse =
+        await githubGraphQL<OpenPrPageResponse>(
+          `
+        query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequests(first: $pageSize, after: $cursor, states: OPEN) {
+              nodes {
+                number
+                url
+                body
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+        `,
+          {owner, repo, pageSize: PAGE_SIZE, cursor: prCursor},
+        );
+
+      const prConnection: OpenPrPageResponse['repository']['pullRequests'] =
+        prResponse.repository.pullRequests;
+
+      for (const pr of prConnection.nodes) {
+        const body = pr.body ?? '';
+        const matches = body.matchAll(/#(\d+)/g);
+        for (const match of matches) {
+          const issueNum = parseInt(match[1]!, 10);
+          if (!issueToOpenPr.has(issueNum)) {
+            issueToOpenPr.set(issueNum, {number: pr.number, url: pr.url});
+          }
+        }
+      }
+
+      prCursor = prConnection.pageInfo.endCursor;
+      prHasNextPage = prConnection.pageInfo.hasNextPage && prCursor !== null;
+    }
+
     const claimed: ClaimInfo[] = [];
     const unclaimed: ClaimInfo[] = [];
     let cursor: string | null = null;
@@ -602,9 +662,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
         );
 
       const connection = response.repository.issues;
-      const nodes = connection.nodes;
 
-      for (const node of nodes) {
+      for (const node of connection.nodes) {
         let matchedClaim: {
           claimer: string;
           keyword: string;
@@ -625,6 +684,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
           }
         }
 
+        const linkedPr = issueToOpenPr.get(node.number) ?? null;
+
         const info: ClaimInfo = {
           issueNumber: node.number,
           title: node.title,
@@ -632,6 +693,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
           claimedBy: matchedClaim?.claimer ?? null,
           matchedKeyword: matchedClaim?.keyword ?? null,
           claimedAt: matchedClaim?.createdAt ?? null,
+          linkedPrNumber: linkedPr?.number ?? null,
+          linkedPrUrl: linkedPr?.url ?? null,
         };
 
         if (matchedClaim) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -416,7 +416,13 @@ const getTaskDeadline = (title: string): {type: string; hours: number} => {
 const getDeadlineStatus = (
   claimedAt: string,
   deadlineHours: number,
+  linkedPrNumber: number | null,
+  linkedPrUrl: string | null,
 ): string => {
+  if (linkedPrNumber !== null) {
+    return `PR 생성됨 - #${linkedPrNumber} (${linkedPrUrl})`;
+  }
+
   const start = new Date(claimedAt).getTime();
   const now = new Date().getTime();
   const deadline = start + deadlineHours * 60 * 60 * 1000;
@@ -449,7 +455,7 @@ export const printClaims = (claims: RepoClaims): void => {
       console.log(`  URL: ${c.url}`);
       if (c.claimedAt) {
         const {type, hours} = getTaskDeadline(c.title);
-        const status = getDeadlineStatus(c.claimedAt, hours);
+        const status = getDeadlineStatus(c.claimedAt, hours, c.linkedPrNumber, c.linkedPrUrl);
         console.log(`  선점자: ${c.claimedBy}`);
         console.log(`  상태: ${type} [${hours}시간 기한] | ${status}`);
       } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,8 @@ export interface ClaimInfo {
   claimedBy: string | null;
   matchedKeyword: string | null;
   claimedAt: string | null;
+  linkedPrNumber: number | null;
+  linkedPrUrl: string | null;
 }
 
 /** 저장소별 선점 현황 */


### PR DESCRIPTION
### ISSUE_ID
Closes #245

### 변경사항
- [x] `ClaimInfo`에 `linkedPrNumber`, `linkedPrUrl` 필드 추가
- [x] `getRecentClaimsData`에서 열린 PR 목록을 조회하고 PR 본문의 `#이슈번호`를 파싱해 이슈와 연결
- [x] 연결된 열린 PR이 있는 이슈는 "기한 초과 - 재선점 가능" 대신 "PR 생성됨 - #PR번호" 로 표시

### 🧪 테스트 방법 (선택 사항)
1. 이슈에 선점 댓글 작성
2. 기한을 넘긴 뒤 해당 이슈를 참조하는 열린 PR 생성
3. `--claims` 실행
4. "기한 초과" 대신 "PR 생성됨 - #PR번호" 로 표시되는지 확인

### 💬 참고 사항 (선택 사항)
reposcore-cs의 `FormatClaimStatus`와 동일한 방식으로 구현했습니다.