### PR TITLE
feat: `--claims` 조회에 증분 캐시 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   -f, --format <format>  출력 형식 (csv, txt, html) (default: csv)
   --output-dir <path>    결과 파일을 저장할 디렉터리 (default: output)
   --no-cache             캐시를 무시하고 GitHub API를 새로 호출합니다 (default: true)
+  --since <since>        캐시 이후 증분 수집 기준 시점 ISO8601 
   --sort-by <field>      정렬 기준 (score, id) (default: score)
   --sort-order <order>   정렬 방식 (asc, desc) (default: desc)
   --claims               최근 이슈 선점 현황을 조회합니다 

--- a/index.ts
+++ b/index.ts
@@ -98,7 +98,7 @@ cli
 
       const rawPageSize =
         options.pageSize === '$PAGE_SIZE'
-          ? Bun.env.PAGE_SIZE ?? 100
+          ? (Bun.env.PAGE_SIZE ?? 100)
           : options.pageSize;
       const pageSize = Number(rawPageSize);
 
@@ -205,6 +205,7 @@ cli
               repoName,
               claimKeywords,
               repoPath,
+              useCache,
             );
             printClaims(claims);
           } catch (error: unknown) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -14,10 +14,14 @@ export interface RepoCache<T> {
  * 저장소별 캐시 파일 경로를 생성합니다.
  * @param owner 저장소 소유자
  * @param repo 저장소 이름
+ * @param cacheKey 캐시 파일 구분 키 (기본값: 'cache')
  * @returns 저장소 캐시 파일 경로
  */
-const getCacheFilePath = (owner: string, repo: string): string =>
-  `${CACHE_DIR}/${owner}_${repo}/cache.json`;
+const getCacheFilePath = (
+  owner: string,
+  repo: string,
+  cacheKey = 'cache',
+): string => `${CACHE_DIR}/${owner}_${repo}/${cacheKey}.json`;
 
 /**
  * 저장소의 캐시 파일을 읽어 기존 분석 결과를 불러옵니다.
@@ -25,19 +29,21 @@ const getCacheFilePath = (owner: string, repo: string): string =>
  * @param owner 저장소 소유자
  * @param repo 저장소 이름
  * @param noCache 캐시 사용을 건너뛸지 여부
+ * @param cacheKey 캐시 파일 구분 키 (기본값: 'cache')
  * @returns 저장소 캐시 데이터 또는 null
  */
 export const loadCache = async <T>(
   owner: string,
   repo: string,
   noCache = false,
+  cacheKey = 'cache',
 ): Promise<RepoCache<T> | null> => {
   if (noCache) {
     console.error('캐시를 무시하고 전체 데이터를 다시 수집합니다.');
     return null;
   }
 
-  const cacheFile = getCacheFilePath(owner, repo);
+  const cacheFile = getCacheFilePath(owner, repo, cacheKey);
   const file = Bun.file(cacheFile);
 
   if (!(await file.exists())) return null;
@@ -61,6 +67,7 @@ export const loadCache = async <T>(
  * @param repo 저장소 이름
  * @param data 캐시에 저장할 분석 결과 데이터
  * @param analyzedAt 분석 기준 시각
+ * @param cacheKey 캐시 파일 구분 키 (기본값: 'cache')
  * @returns 반환값이 없습니다.
  */
 export const saveCache = async <T>(
@@ -68,6 +75,7 @@ export const saveCache = async <T>(
   repo: string,
   data: T,
   analyzedAt = new Date().toISOString(),
+  cacheKey = 'cache',
 ): Promise<void> => {
   const cache: RepoCache<T> = {
     repository: `${owner}/${repo}`,
@@ -76,7 +84,7 @@ export const saveCache = async <T>(
   };
 
   await Bun.write(
-    getCacheFilePath(owner, repo),
+    getCacheFilePath(owner, repo, cacheKey),
     JSON.stringify(cache, null, 2),
   );
 

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -33,6 +33,19 @@ interface ClaimsPageResponse {
   };
 }
 
+interface OpenPrPageResponse {
+  repository: {
+    pullRequests: {
+      nodes: {
+        number: number;
+        url: string;
+        body: string | null;
+      }[];
+      pageInfo: PageInfo;
+    };
+  };
+}
+
 interface ClaimsSearchResponse {
   search: {
     nodes: Array<{
@@ -574,48 +587,45 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
   };
 
   /**
-   * 저장소의 열린 이슈와 최근 댓글을 모두 조회합니다 (전체 조회).
+   * 저장소의 열린 PR 본문에서 이슈 번호를 파싱해 이슈 번호 → 열린 PR 매핑을 반환합니다.
    * @param owner 저장소 소유자
    * @param repo 저장소 이름
-   * @returns 열린 이슈 목록 (댓글 포함)
+   * @returns 이슈 번호 → {number, url} 열린 PR 매핑
    */
-  const getAllOpenIssuesWithComments = async (
+  const getOpenPrIssueMap = async (
     owner: string,
     repo: string,
-    keywords: string[],
-    repoPath: string,
-  ): Promise<RepoClaims> => {
+  ): Promise<Map<number, {number: number; url: string}>> => {
     const issueToOpenPr = new Map<number, {number: number; url: string}>();
-    let prCursor: string | null = null;
-    let prHasNextPage = true;
+    let cursor: string | null = null;
+    let hasNextPage = true;
 
-    while (prHasNextPage) {
-      const prResponse: OpenPrPageResponse =
+    while (hasNextPage) {
+      const response: OpenPrPageResponse =
         await githubGraphQL<OpenPrPageResponse>(
           `
-        query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequests(first: $pageSize, after: $cursor, states: OPEN) {
-              nodes {
-                number
-                url
-                body
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
+          query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
+            repository(owner: $owner, name: $repo) {
+              pullRequests(first: $pageSize, after: $cursor, states: OPEN) {
+                nodes {
+                  number
+                  url
+                  body
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
             }
           }
-        }
-        `,
-          {owner, repo, pageSize: PAGE_SIZE, cursor: prCursor},
+          `,
+          {owner, repo, pageSize, cursor},
         );
 
-      const prConnection: OpenPrPageResponse['repository']['pullRequests'] =
-        prResponse.repository.pullRequests;
+      const connection = response.repository.pullRequests;
 
-      for (const pr of prConnection.nodes) {
+      for (const pr of connection.nodes) {
         const body = pr.body ?? '';
         const matches = body.matchAll(/#(\d+)/g);
         for (const match of matches) {
@@ -626,12 +636,24 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
         }
       }
 
-      prCursor = prConnection.pageInfo.endCursor;
-      prHasNextPage = prConnection.pageInfo.hasNextPage && prCursor !== null;
+      cursor = connection.pageInfo.endCursor;
+      hasNextPage = connection.pageInfo.hasNextPage && cursor !== null;
     }
 
-    const claimed: ClaimInfo[] = [];
-    const unclaimed: ClaimInfo[] = [];
+    return issueToOpenPr;
+  };
+
+  /**
+   * 저장소의 열린 이슈와 최근 댓글을 모두 조회합니다 (전체 조회).
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @returns 열린 이슈 목록 (댓글 포함)
+   */
+  const getAllOpenIssuesWithComments = async (
+    owner: string,
+    repo: string,
+  ): Promise<ClaimsIssueNode[]> => {
+    const issues: ClaimsIssueNode[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -662,7 +684,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
             }
           }
           `,
-          {owner, repo, pageSize: PAGE_SIZE, cursor},
+          {owner, repo, pageSize, cursor},
         );
 
       const connection = response.repository.issues;
@@ -761,16 +783,24 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       'claims-cache',
     );
 
+    const [issueToOpenPr, openIssuesResult] = await (cached
+      ? Promise.all([
+          getOpenPrIssueMap(owner, repo),
+          getUpdatedIssuesWithComments(owner, repo, cached.lastAnalyzedAt),
+        ])
+      : Promise.all([
+          getOpenPrIssueMap(owner, repo),
+          getAllOpenIssuesWithComments(owner, repo),
+        ]));
+
     let openIssues: ClaimsIssueNode[];
 
     if (!cached) {
-      openIssues = await getAllOpenIssuesWithComments(owner, repo);
+      openIssues = openIssuesResult as ClaimsIssueNode[];
     } else {
-      const updatedIssues = await getUpdatedIssuesWithComments(
-        owner,
-        repo,
-        cached.lastAnalyzedAt,
-      );
+      const updatedIssues = openIssuesResult as Array<
+        ClaimsIssueNode & {state: string}
+      >;
 
       // 닫힌 이슈 번호 집합 — 캐시에서 제거 대상
       const closedNumbers = new Set(
@@ -827,6 +857,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
         }
       }
 
+      const linkedPr = issueToOpenPr.get(node.number) ?? null;
+
       const info: ClaimInfo = {
         issueNumber: node.number,
         title: node.title,
@@ -834,6 +866,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
         claimedBy: matchedClaim?.claimer ?? null,
         matchedKeyword: matchedClaim?.keyword ?? null,
         claimedAt: matchedClaim?.createdAt ?? null,
+        linkedPrNumber: linkedPr?.number ?? null,
+        linkedPrUrl: linkedPr?.url ?? null,
       };
 
       if (matchedClaim) {

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -4,6 +4,8 @@ import type {
   ContributionLabel,
   DetailedRepoData,
   ClaimInfo,
+  ClaimsIssueNode,
+  ClaimsData,
   RepoClaims,
   IssueRecord,
   PRRecord,
@@ -28,6 +30,25 @@ interface ClaimsPageResponse {
       }[];
       pageInfo: PageInfo;
     };
+  };
+}
+
+interface ClaimsSearchResponse {
+  search: {
+    nodes: Array<{
+      number: number;
+      title: string;
+      url: string;
+      state: string;
+      comments: {
+        nodes: {
+          body: string;
+          author: {login: string} | null;
+          createdAt: string;
+        }[];
+      };
+    }>;
+    pageInfo: PageInfo;
   };
 }
 
@@ -546,39 +567,93 @@ export const createGitHubService = (token: string) => {
   };
 
   /**
-   * 열린 이슈와 최근 댓글을 조회하여 선점 키워드가 포함된 이슈를 분류합니다.
+   * 저장소의 열린 이슈와 최근 댓글을 모두 조회합니다 (전체 조회).
    * @param owner 저장소 소유자
    * @param repo 저장소 이름
-   * @param keywords 선점 여부를 판단할 키워드 목록
-   * @param repoPath 출력에 사용할 저장소 경로
-   * @returns 선점된 이슈와 선점되지 않은 이슈 목록
+   * @returns 열린 이슈 목록 (댓글 포함)
    */
-  const getRecentClaimsData = async (
+  const getAllOpenIssuesWithComments = async (
     owner: string,
     repo: string,
-    keywords: string[],
-    repoPath: string,
-  ): Promise<RepoClaims> => {
-    const claimed: ClaimInfo[] = [];
-    const unclaimed: ClaimInfo[] = [];
+  ): Promise<ClaimsIssueNode[]> => {
+    const issues: ClaimsIssueNode[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
     while (hasNextPage) {
-      const response: ClaimsPageResponse = await githubGraphQL<ClaimsPageResponse>(
-        `
-        query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            issues(first: $pageSize, after: $cursor, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+      const response: ClaimsPageResponse =
+        await githubGraphQL<ClaimsPageResponse>(
+          `
+          query($owner: String!, $repo: String!, $pageSize: Int!, $cursor: String) {
+            repository(owner: $owner, name: $repo) {
+              issues(first: $pageSize, after: $cursor, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+                nodes {
+                  number
+                  title
+                  url
+                  comments(last: 10) {
+                    nodes {
+                      body
+                      author { login }
+                      createdAt
+                    }
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+          `,
+          {owner, repo, pageSize: PAGE_SIZE, cursor},
+        );
+
+      const connection = response.repository.issues;
+      issues.push(...connection.nodes);
+
+      cursor = connection.pageInfo.endCursor;
+      hasNextPage = connection.pageInfo.hasNextPage && cursor !== null;
+    }
+
+    return issues;
+  };
+
+  /**
+   * 지정한 시점 이후 변경된 이슈(열림/닫힘 모두)와 최근 댓글을 조회합니다 (증분 조회).
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @param since 변경 내역을 조회할 기준 시각
+   * @returns 기준 시각 이후 변경된 이슈 목록 (state 포함, 댓글 포함)
+   */
+  const getUpdatedIssuesWithComments = async (
+    owner: string,
+    repo: string,
+    since: string,
+  ): Promise<Array<ClaimsIssueNode & {state: string}>> => {
+    const issues: Array<ClaimsIssueNode & {state: string}> = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const response: ClaimsSearchResponse =
+        await githubGraphQL<ClaimsSearchResponse>(
+          `
+          query($searchQuery: String!, $pageSize: Int!, $cursor: String) {
+            search(query: $searchQuery, type: ISSUE, first: $pageSize, after: $cursor) {
               nodes {
-                number
-                title
-                url
-                comments(last: 10) {
-                  nodes {
-                    body
-                    author { login }
-                    createdAt
+                ... on Issue {
+                  number
+                  title
+                  url
+                  state
+                  comments(last: 10) {
+                    nodes {
+                      body
+                      author { login }
+                      createdAt
+                    }
                   }
                 }
               }
@@ -588,53 +663,129 @@ export const createGitHubService = (token: string) => {
               }
             }
           }
-        }
-        `,
-        {owner, repo, pageSize: PAGE_SIZE, cursor},
+          `,
+          {
+            searchQuery: `repo:${owner}/${repo} is:issue updated:>=${since}`,
+            pageSize: PAGE_SIZE,
+            cursor,
+          },
+        );
+
+      issues.push(...response.search.nodes);
+
+      cursor = response.search.pageInfo.endCursor;
+      hasNextPage = response.search.pageInfo.hasNextPage && cursor !== null;
+    }
+
+    return issues;
+  };
+
+  /**
+   * 열린 이슈와 최근 댓글을 조회하여 선점 키워드가 포함된 이슈를 분류합니다.
+   * 캐시가 있으면 마지막 분석 시점 이후의 변경분만 조회해 병합하고,
+   * 캐시가 없으면 전체 데이터를 새로 수집합니다.
+   * @param owner 저장소 소유자
+   * @param repo 저장소 이름
+   * @param keywords 선점 여부를 판단할 키워드 목록
+   * @param repoPath 출력에 사용할 저장소 경로
+   * @param useCache 캐시 사용 여부
+   * @returns 선점된 이슈와 선점되지 않은 이슈 목록
+   */
+  const getRecentClaimsData = async (
+    owner: string,
+    repo: string,
+    keywords: string[],
+    repoPath: string,
+    useCache = true,
+  ): Promise<RepoClaims> => {
+    const analysisStartedAt = new Date().toISOString();
+    const cached = await loadCache<ClaimsData>(
+      owner,
+      repo,
+      !useCache,
+      'claims-cache',
+    );
+
+    let openIssues: ClaimsIssueNode[];
+
+    if (!cached) {
+      openIssues = await getAllOpenIssuesWithComments(owner, repo);
+    } else {
+      const updatedIssues = await getUpdatedIssuesWithComments(
+        owner,
+        repo,
+        cached.lastAnalyzedAt,
       );
 
-      const connection = response.repository.issues;
-      const nodes = connection.nodes;
+      // 닫힌 이슈 번호 집합 — 캐시에서 제거 대상
+      const closedNumbers = new Set(
+        updatedIssues.filter(i => i.state === 'CLOSED').map(i => i.number),
+      );
 
-      for (const node of nodes) {
-        let matchedClaim: {
-          claimer: string;
-          keyword: string;
-          createdAt: string;
-        } | null = null;
-        
-        const comments = [...node.comments.nodes].reverse();
+      // 캐시에서 닫힌 이슈 제거
+      const filteredCached = cached.data.issues.filter(
+        i => !closedNumbers.has(i.number),
+      );
 
-        for (const comment of comments) {
-          const foundKeyword = keywords.find(k => comment.body.includes(k));
-          if (foundKeyword) {
-            matchedClaim = {
-              claimer: comment.author?.login ?? 'unknown',
-              keyword: foundKeyword,
-              createdAt: comment.createdAt,
-            };
-            break;
-          }
-        }
+      // 업데이트된 열린 이슈만 추출 (state 필드 제거)
+      const openUpdated: ClaimsIssueNode[] = updatedIssues
+        .filter(i => i.state === 'OPEN')
+        .map(({number, title, url, comments}) => ({
+          number,
+          title,
+          url,
+          comments,
+        }));
 
-        const info: ClaimInfo = {
-          issueNumber: node.number,
-          title: node.title,
-          url: node.url,
-          claimedBy: matchedClaim?.claimer ?? null,
-          matchedKeyword: matchedClaim?.keyword ?? null,
-          claimedAt: matchedClaim?.createdAt ?? null,
-      };
+      openIssues = mergeByNumber(filteredCached, openUpdated);
+    }
 
-        if (matchedClaim) {
-          claimed.push(info);
-        } else {
-          unclaimed.push(info);
+    await saveCache<ClaimsData>(
+      owner,
+      repo,
+      {issues: openIssues},
+      analysisStartedAt,
+      'claims-cache',
+    );
+
+    const claimed: ClaimInfo[] = [];
+    const unclaimed: ClaimInfo[] = [];
+
+    for (const node of openIssues) {
+      let matchedClaim: {
+        claimer: string;
+        keyword: string;
+        createdAt: string;
+      } | null = null;
+
+      const comments = [...node.comments.nodes].reverse();
+
+      for (const comment of comments) {
+        const foundKeyword = keywords.find(k => comment.body.includes(k));
+        if (foundKeyword) {
+          matchedClaim = {
+            claimer: comment.author?.login ?? 'unknown',
+            keyword: foundKeyword,
+            createdAt: comment.createdAt,
+          };
+          break;
         }
       }
 
-      cursor = connection.pageInfo.endCursor;
-      hasNextPage = connection.pageInfo.hasNextPage && cursor !== null;
+      const info: ClaimInfo = {
+        issueNumber: node.number,
+        title: node.title,
+        url: node.url,
+        claimedBy: matchedClaim?.claimer ?? null,
+        matchedKeyword: matchedClaim?.keyword ?? null,
+        claimedAt: matchedClaim?.createdAt ?? null,
+      };
+
+      if (matchedClaim) {
+        claimed.push(info);
+      } else {
+        unclaimed.push(info);
+      }
     }
 
     return {repoPath, claimed, unclaimed};

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,34 @@ export interface DetailedRepoData {
   issues: IssueRecord[];
 }
 
+/**
+ * 선점 캐시에 저장되는 열린 이슈 노드입니다.
+ */
+export interface ClaimsIssueNode {
+  /** GitHub 이슈 번호. */
+  number: number;
+  /** 제목. */
+  title: string;
+  /** GitHub 웹 URL. */
+  url: string;
+  /** 선점 키워드 판별에 사용할 댓글 목록. */
+  comments: {
+    nodes: {
+      body: string;
+      author: {login: string} | null;
+      createdAt: string;
+    }[];
+  };
+}
+
+/**
+ * 선점 조회 경로의 캐시 저장 데이터입니다.
+ */
+export interface ClaimsData {
+  /** 열린 이슈 목록(댓글 포함). */
+  issues: ClaimsIssueNode[];
+}
+
 /** 선점된 이슈 정보 */
 export interface ClaimInfo {
   issueNumber: number;
@@ -121,6 +149,7 @@ export interface ClaimService {
     repoName: string,
     keywords: string[],
     repoPath: string,
+    useCache?: boolean,
   ): Promise<RepoClaims>;
 }
 


### PR DESCRIPTION
### ISSUE_ID
Closes #246

### 변경사항
- [x] `src/cache.ts`: `getCacheFilePath`, `loadCache`, `saveCache`에 `cacheKey` 파라미터 추가 (기본값 `'cache'`, 하위 호환 유지)
- [x] `src/types.ts`: `ClaimsIssueNode`, `ClaimsData` 인터페이스 추가 및 `ClaimService.getRecentClaimsData` 시그니처에 `useCache?: boolean` 파라미터 추가
- [x] `src/github-service.ts`: `getRecentClaimsData`에 증분 캐시 적용
  - 전체 조회 헬퍼 `getAllOpenIssuesWithComments()` 추가
  - 증분 조회 헬퍼 `getUpdatedIssuesWithComments()` 추가 (`updated:>=since` 검색, `state` 포함)
  - 캐시 없음 → 전체 조회 / 캐시 있음 → 증분 조회 후 `mergeByNumber` 병합, 닫힌 이슈 제거
  - 분석 결과를 `.cache/{owner}_{repo}/claims-cache.json`에 저장
- [x] `index.ts`: `--claims` 실행 시 `useCache`(`--no-cache` 반영) 값을 `getRecentClaimsData`에 전달

### 🧪 테스트 방법
1. 최초 실행: `bun run index.ts owner/repo --claims --token $GITHUB_TOKEN`
   - `.cache/{owner}_{repo}/claims-cache.json` 파일이 생성되는지 확인
2. 재실행: 동일 명령을 다시 실행
   - `[cache] owner/repo — 캐시에서 읽습니다.` 로그 출력 확인
   - 이전 실행보다 API 요청 횟수가 줄어드는지 확인 (변경된 이슈만 재조회)
3. 캐시 무시: `--no-cache` 플래그 추가 시 전체 재조회 확인
4. `bun test` — 기존 테스트 16개 전체 통과 확인

### 💬 참고 사항
- 선점 캐시는 기존 점수 캐시(`cache.json`)와 분리된 `claims-cache.json` 파일에 저장됩니다.
- `getUpdatedIssuesWithComments`는 `state`(OPEN/CLOSED)를 포함해 조회하므로, 캐시 이후 닫힌 이슈를 자동으로 제거합니다.
- 이슈 #244(페이지네이션 누락)와 연관됩니다. 현재 구현은 전체 조회 시 페이지네이션을 적용하고 있으나, #244 수정 전에는 캐시 초기화 시 불완전한 데이터가 저장될 수 있습니다.