### PR TITLE
fix: --claims 선점 키워드 공백 정규화

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -111,6 +111,9 @@ interface GetDetailedRepoDataOptions {
 
 const PAGE_SIZE = 100;
 
+const normalizeWhitespace = (text: string): string =>
+  text.replace(/\s+/g, '').toLowerCase();
+
 /**
  * GitHub 라벨명을 내부 기여 카테고리로 정규화합니다.
  * @param label 정규화할 GitHub 라벨명
@@ -846,7 +849,10 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       const comments = [...node.comments.nodes].reverse();
 
       for (const comment of comments) {
-        const foundKeyword = keywords.find(k => comment.body.includes(k));
+        const normalizedBody = normalizeWhitespace(comment.body);
+        const foundKeyword = keywords.find(keyword =>
+          normalizedBody.includes(normalizeWhitespace(keyword)),
+        );
         if (foundKeyword) {
           matchedClaim = {
             claimer: comment.author?.login ?? 'unknown',


### PR DESCRIPTION
### ISSUE_ID

Closes #264

### 변경사항

- [x] `--claims` 선점 키워드 매칭 시 댓글 본문과 키워드의 공백을 정규화하도록 수정했습니다.
- [x] 댓글 본문에 공백, 줄바꿈, 탭 등이 섞여 있어도 선점 키워드를 감지할 수 있도록 했습니다.
- [x] 기존 matched keyword는 사용자가 입력한 원래 키워드 값을 유지하도록 했습니다.

### 테스트 방법

```bash
bun install
npm test
npm run typecheck
npm run lint
```

### 테스트 결과

```text
npm test
16 pass
0 fail
36 expect() calls
```

```text
npm run typecheck
tsc --noEmit
```

`npm run typecheck`는 오류 없이 통과했습니다.

`npm run lint`는 실행했으나, 이번 PR에서 수정한 `src/github-service.ts`가 아닌 기존 파일에서 lint 오류가 발생했습니다.

```text
src/output.ts
src/score-calculator.ts
```

따라서 이번 PR에서는 #264 범위에 맞춰 `src/github-service.ts`의 선점 키워드 공백 정규화 로직만 수정했습니다.

### 참고 사항

기존에는 `comment.body.includes(k)`로 원문 문자열을 직접 비교하여 공백이나 줄바꿈이 섞인 경우 키워드 매칭이 실패할 수 있었습니다.

이번 수정에서는 댓글 본문과 키워드 모두에서 공백을 제거하고 소문자로 변환한 뒤 비교하여, `제가 하겠습니다`, `제가   하겠습니다`, `제가\n하겠습니다` 같은 표현을 같은 선점 키워드로 인식할 수 있도록 했습니다.

`npm run build`는 현재 `package.json`에 정의되어 있지 않아 실행하지 않았습니다.