### PR TITLE
--claims 키워드 공백 정규화 테스트 추가

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -111,7 +111,7 @@ interface GetDetailedRepoDataOptions {
 
 const PAGE_SIZE = 100;
 
-const normalizeWhitespace = (text: string): string =>
+export const normalizeWhitespace = (text: string): string =>
   text.replace(/\s+/g, '').toLowerCase();
 
 /**

--- a/tests/github-service.test.ts
+++ b/tests/github-service.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, test} from 'bun:test';
+
+import {normalizeWhitespace} from '../src/github-service';
+
+describe('claims keyword whitespace normalization', () => {
+  test('선점 키워드의 공백 차이를 제거해 같은 문자열로 정규화한다', () => {
+    const keyword = normalizeWhitespace('제가 하겠습니다');
+
+    expect(normalizeWhitespace('제가 하겠습니다')).toBe(keyword);
+    expect(normalizeWhitespace('제가   하겠습니다')).toBe(keyword);
+    expect(normalizeWhitespace('제가\n하겠습니다')).toBe(keyword);
+    expect(normalizeWhitespace('제가\t하겠습니다')).toBe(keyword);
+  });
+
+  test('대소문자 차이를 무시하도록 소문자로 정규화한다', () => {
+    expect(normalizeWhitespace('I WILL DO THIS')).toBe(
+      normalizeWhitespace('i will do this'),
+    );
+  });
+});


### PR DESCRIPTION
### ISSUE_ID

Closes #267

### 변경사항

- [x] `normalizeWhitespace` 함수를 테스트할 수 있도록 export했습니다.
- [x] `--claims` 선점 키워드 공백 정규화 동작을 검증하는 테스트를 추가했습니다.
- [x] 여러 개의 공백, 줄바꿈, 탭이 포함된 댓글도 같은 선점 키워드로 정규화되는지 확인했습니다.
- [x] 대소문자 차이를 무시하도록 소문자 정규화가 적용되는지도 확인했습니다.

### 테스트 방법

```bash
bun install
npm test
npm run typecheck
```

### 테스트 결과

```text
npm test
18 pass
0 fail
41 expect() calls
```

```text
npm run typecheck
tsc --noEmit
```

`npm run typecheck`는 오류 없이 통과했습니다.

### 참고 사항

#264에서 `--claims` 선점 키워드 매칭 시 공백 정규화 문제가 수정되었습니다.

이번 PR은 #267 이슈 범위에 맞춰 해당 동작이 이후 변경 과정에서 다시 깨지지 않도록 회귀 테스트를 추가하는 작업입니다.