### PR TITLE
`--claims` 선점 기한 판정을 제목이 아닌 라벨 기준으로 수정

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -20,6 +20,7 @@ interface ClaimsPageResponse {
         number: number;
         title: string;
         url: string;
+        labels: {nodes: {name: string}[]};
         comments: {
           nodes: {
             body: string;
@@ -53,6 +54,7 @@ interface ClaimsSearchResponse {
       title: string;
       url: string;
       state: string;
+      labels: {nodes: {name: string}[]};
       comments: {
         nodes: {
           body: string;
@@ -671,6 +673,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
                   number
                   title
                   url
+                  labels(first: 20) { nodes { name } }
                   comments(last: 10) {
                     nodes {
                       body
@@ -728,6 +731,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
                   title
                   url
                   state
+                  labels(first: 20) { nodes { name } }
                   comments(last: 10) {
                     nodes {
                       body
@@ -818,10 +822,11 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       // 업데이트된 열린 이슈만 추출 (state 필드 제거)
       const openUpdated: ClaimsIssueNode[] = updatedIssues
         .filter(i => i.state === 'OPEN')
-        .map(({number, title, url, comments}) => ({
+        .map(({number, title, url, labels, comments}) => ({
           number,
           title,
           url,
+          labels,
           comments,
         }));
 
@@ -869,6 +874,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
         issueNumber: node.number,
         title: node.title,
         url: node.url,
+        labels: node.labels,
         claimedBy: matchedClaim?.claimer ?? null,
         matchedKeyword: matchedClaim?.keyword ?? null,
         claimedAt: matchedClaim?.createdAt ?? null,

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,5 +1,5 @@
 import {mkdir} from 'node:fs/promises';
-import {countByCategory} from './github-service';
+import {categorizeLabels, countByCategory} from './github-service';
 import type {DetailedRepoData, RepoClaims} from './types';
 import {ScoreCalculator, type UserScore} from './score-calculator'; // ScoreCalculator 클래스 임포트 추가
 
@@ -285,8 +285,8 @@ export const buildHtmlReport = (data: ScoreOutputData): string => {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>RepoScore Report</title>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"><\/script>
-  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"><\/script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
   <style>
     body { font-family: sans-serif; padding: 20px; }
     h1 { border-bottom: 2px solid #eee; padding-bottom: 10px; }
@@ -351,7 +351,7 @@ export const buildHtmlReport = (data: ScoreOutputData): string => {
         }
       }
     });
-  <\/script>
+  </script>
 </body>
 </html>`;
 };
@@ -400,12 +400,15 @@ export const writeOutputFiles = async (
 };
 
 /**
- * 이슈 제목을 기반으로 작업 유형 및 기한(시간)을 결정합니다.
- * issue-pr-guide.md의 규칙을 따릅니다.
+ * 이슈 라벨을 기반으로 작업 유형 및 기한(시간)을 결정합니다.
+ * documentation/typo 계열 라벨은 문서 작업(24h), 그 외는 코드 작업(48h)으로 처리합니다.
  */
-const getTaskDeadline = (title: string): {type: string; hours: number} => {
-  const lowerTitle = title.toLowerCase();
-  const isDoc = /docs|readme|문서|오타|typo/i.test(lowerTitle);
+const getTaskDeadline = (labels: {
+  nodes: {name: string}[];
+}): {type: string; hours: number} => {
+  const labelNames = labels.nodes.map(node => node.name);
+  const category = categorizeLabels(labelNames);
+  const isDoc = category === 'doc' || category === 'typo';
 
   return isDoc ? {type: '문서', hours: 24} : {type: '코드', hours: 48};
 };
@@ -454,8 +457,13 @@ export const printClaims = (claims: RepoClaims): void => {
       console.log(`- #${c.issueNumber} ${c.title}`);
       console.log(`  URL: ${c.url}`);
       if (c.claimedAt) {
-        const {type, hours} = getTaskDeadline(c.title);
-        const status = getDeadlineStatus(c.claimedAt, hours, c.linkedPrNumber, c.linkedPrUrl);
+        const {type, hours} = getTaskDeadline(c.labels);
+        const status = getDeadlineStatus(
+          c.claimedAt,
+          hours,
+          c.linkedPrNumber,
+          c.linkedPrUrl,
+        );
         console.log(`  선점자: ${c.claimedBy}`);
         console.log(`  상태: ${type} [${hours}시간 기한] | ${status}`);
       } else {

--- a/src/score-calculator.ts
+++ b/src/score-calculator.ts
@@ -236,7 +236,7 @@ export class ScoreCalculator {
     }
 
     return Array.from(byUser.entries()).map(([userId, repoScores]) => {
-      const dummyUser: UserScore = { userId, repoScores, totalScore: 0 };
+      const dummyUser: UserScore = {userId, repoScores, totalScore: 0};
       const aggregated = ScoreCalculator.getAccumulatedContributions(dummyUser);
 
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,8 @@ export interface ClaimsIssueNode {
   title: string;
   /** GitHub 웹 URL. */
   url: string;
+  /** 이슈 라벨 목록. */
+  labels: {nodes: {name: string}[]};
   /** 선점 키워드 판별에 사용할 댓글 목록. */
   comments: {
     nodes: {
@@ -131,6 +133,7 @@ export interface ClaimInfo {
   issueNumber: number;
   title: string;
   url: string;
+  labels: {nodes: {name: string}[]};
   claimedBy: string | null;
   matchedKeyword: string | null;
   claimedAt: string | null;

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, test} from 'bun:test';
-import {buildUserScoresTxt, type ScoreOutputData} from '../src/output';
+import {
+  buildUserScoresTxt,
+  printClaims,
+  type ScoreOutputData,
+} from '../src/output';
+import type {RepoClaims} from '../src/types';
 
 const analyzedAt = new Date(2026, 5, 4, 9, 30);
 
@@ -104,5 +109,58 @@ describe('TXT 리포트 출력', () => {
     expect(result).toContain(
       '[추가 제안] 기능/버그 PR 1개 추가 시 문서PR 인정 한도 +3',
     );
+  });
+});
+
+describe('선점 기한 판정', () => {
+  test('이슈 제목이 아닌 라벨 기준으로 문서/코드 기한을 출력해야 한다', () => {
+    const claims: RepoClaims = {
+      repoPath: 'oss2026hnu/reposcore-ts',
+      claimed: [
+        {
+          issueNumber: 101,
+          title: 'Refactor parser module',
+          url: 'https://example.com/issues/101',
+          labels: {
+            nodes: [{name: 'documentation'}],
+          },
+          claimedBy: 'alpha',
+          matchedKeyword: '/claim',
+          claimedAt: '2026-06-12T00:00:00.000Z',
+          linkedPrNumber: 55,
+          linkedPrUrl: 'https://example.com/pull/55',
+        },
+        {
+          issueNumber: 102,
+          title: '문서 개선 요청',
+          url: 'https://example.com/issues/102',
+          labels: {
+            nodes: [],
+          },
+          claimedBy: 'beta',
+          matchedKeyword: '/claim',
+          claimedAt: '2026-06-12T00:00:00.000Z',
+          linkedPrNumber: 56,
+          linkedPrUrl: 'https://example.com/pull/56',
+        },
+      ],
+      unclaimed: [],
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(value => String(value)).join(' '));
+    };
+
+    try {
+      printClaims(claims);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const joined = logs.join('\n');
+    expect(joined).toContain('상태: 문서 [24시간 기한]');
+    expect(joined).toContain('상태: 코드 [48시간 기한]');
   });
 });


### PR DESCRIPTION
### ISSUE_ID

Closes #262

### 변경사항
- [x] claims 선점 기한 판정을 제목 기반에서 라벨 기반으로 변경
- [x] claims 조회 경로에서 이슈 라벨 정보를 함께 수집하도록 타입/쿼리 반영
- [x] claims 기한 판정 회귀 테스트 추가
- [x] 린트 오류 수정 완료
  - `no-useless-escape` 관련 escape 문자 정리
  - lint 대상에서 불필요한 가상환경 경로 제외 처리

### 🧪 테스트 방법 (선택 사항)
1. 자동 테스트
- `bun run lint`
- `bun test`

2. claims 동작 수동 확인
- 라벨이 `documentation`이고 제목에 문서 키워드가 없는 이슈를 준비
- 해당 이슈에 선점 댓글 작성 후 `--claims` 실행
- 기대 결과: `문서 [24시간 기한]`으로 표시

- 라벨이 없고 제목에 `문서` 키워드가 포함된 이슈를 준비
- 해당 이슈에 선점 댓글 작성 후 `--claims` 실행
- 기대 결과: `코드 [48시간 기한]`으로 표시

3. 회귀 테스트 포인트
- 라벨 기반 판정이 우선되며, 제목 문자열은 기한 판정에 사용되지 않음

### 💬 참고 사항 (선택 사항)
- 문서/코드 기한 판정은 이제 이슈 라벨 기준으로만 동작합니다.
- 제목 문자열 키워드 매칭 기반 판정은 제거되었습니다.