### PR TITLE
fix: 빈 claims 키워드 입력 검증 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,31 @@ function parseRepoPath(repoPath: string) {
   };
 }
 
+/**
+ * CLI 원본 인자에서 --keywords 옵션이 명시적으로 입력되었는지와 값을 확인합니다.
+ */
+function getExplicitKeywordsValue(argv: string[]): string | null {
+  const optionIndex = argv.findIndex(
+    arg => arg === '--keywords' || arg.startsWith('--keywords='),
+  );
+
+  if (optionIndex === -1) {
+    return null;
+  }
+
+  const option = argv[optionIndex]!;
+  if (option.startsWith('--keywords=')) {
+    return option.slice('--keywords='.length);
+  }
+
+  const value = argv[optionIndex + 1];
+  if (!value || value.startsWith('-')) {
+    return '';
+  }
+
+  return value;
+}
+
 cli
   .command('[...repos]', '대상 저장소 목록 (예: owner/repo1 owner/repo2)')
   .option('-t, --token <token>', 'GitHub Personal Access Token', {
@@ -116,13 +141,27 @@ cli
         "I'll take this",
       ];
 
-      const claimKeywords =
-        typeof options.keywords === 'string'
+      const explicitKeywordsValue = getExplicitKeywordsValue(process.argv);
+      const rawKeywords =
+        explicitKeywordsValue ??
+        (typeof options.keywords === 'string'
           ? options.keywords
-              .split(',')
-              .map(k => k.trim())
-              .filter(Boolean)
-          : DEFAULT_KEYWORDS;
+          : DEFAULT_KEYWORDS.join(','));
+
+      const claimKeywords = rawKeywords
+        .split(',')
+        .map(k => k.trim())
+        .filter(Boolean);
+
+      if (
+        isClaimsMode &&
+        explicitKeywordsValue !== null &&
+        claimKeywords.length === 0
+      ) {
+        errors.push(
+          '오류: --keywords에는 하나 이상의 선점 키워드를 입력해야 합니다.',
+        );
+      }
 
       const parsedRepos: {
         repoPath: string;


### PR DESCRIPTION
### ISSUE_ID

Closes #270

### 변경사항

- [x] `--claims` 모드에서 `--keywords`가 명시적으로 입력되었는지 확인하는 로직을 추가했습니다.
- [x] `--keywords ""`, `--keywords ",,,"`처럼 파싱 결과가 빈 배열이 되는 경우 오류 메시지를 출력하고 실행을 중단하도록 수정했습니다.
- [x] 빈 키워드 입력 시 GitHub API 호출까지 진행되어 모든 이슈가 미선점 처리될 수 있는 문제를 방지했습니다.

### 테스트 방법

```bash
npm run lint
npm test
npm run typecheck
bun run index.ts oss2026hnu/reposcore-ts --claims --token dummy --keywords ""
echo $?
bun run index.ts oss2026hnu/reposcore-ts --claims --token dummy --keywords ",,,"
echo $?
```

### 테스트 결과

```text
npm run lint
```

오류 없이 통과했습니다.

```text
npm test
```

```text
19 pass
0 fail
43 expect() calls
```

```text
npm run typecheck
```

오류 없이 통과했습니다.

빈 키워드 재현 테스트:

```text
오류: --keywords에는 하나 이상의 선점 키워드를 입력해야 합니다.
echo $? -> 1
```

```text
--keywords ",,," 입력 시에도 동일하게 오류 메시지를 출력하고 exit code 1로 종료됨을 확인했습니다.
```

### 참고 사항

이번 PR은 `--claims` 모드에서 `--keywords` 입력값이 비어 있는 경우의 검증 누락만 수정합니다