### PR TITLE
-claims 출력 결과를 이슈 번호(issueNumber) 오름차순 기준으로 정렬

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -449,11 +449,21 @@ const getDeadlineStatus = (
 export const printClaims = (claims: RepoClaims): void => {
   console.log(`\n[${claims.repoPath}]`);
 
+  // 1. 원본 배열을 변경하지 않도록 복사([...]) 후 issueNumber 오름차순 정렬
+  const sortedClaimed = [...claims.claimed].sort(
+    (a, b) => a.issueNumber - b.issueNumber,
+  );
+
+  const sortedUnclaimed = [...claims.unclaimed].sort(
+    (a, b) => a.issueNumber - b.issueNumber,
+  );
+
   console.log('선점된 이슈');
-  if (claims.claimed.length === 0) {
+  if (sortedClaimed.length === 0) {
     console.log('  (없음)');
   } else {
-    for (const c of claims.claimed) {
+    // 2. 기존 claims.claimed 대신 정렬된 sortedClaimed 배열을 순회하도록 변경
+    for (const c of sortedClaimed) {
       console.log(`- #${c.issueNumber} ${c.title}`);
       console.log(`  URL: ${c.url}`);
       if (c.claimedAt) {
@@ -473,10 +483,11 @@ export const printClaims = (claims: RepoClaims): void => {
   }
 
   console.log('\n미선점 이슈');
-  if (claims.unclaimed.length === 0) {
+  if (sortedUnclaimed.length === 0) {
     console.log('  (없음)');
   } else {
-    for (const u of claims.unclaimed) {
+    // 3. 기존 claims.unclaimed 대신 정렬된 sortedUnclaimed 배열을 순회하도록 변경
+    for (const u of sortedUnclaimed) {
       console.log(`- #${u.issueNumber} ${u.title}`);
       console.log(`  URL: ${u.url}`);
     }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #271 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 --claims` 출력 시 뒤죽박죽이던 선점/미선점 이슈 목록을 `issueNumber` 오름차순 기준으로 일관되게 정렬
- [ ] 변경 사항 2 원본 배열을 직접 변경하지 않도록 스프레드 연산자(`[...]`)로 안전하게 복사한 후 정렬을 수행
- [ ] 변경 사항 3 이슈 번호 정렬을 통해 사용자가 선점 가능한 현황을 빠르게 비교·확인할 수 있도록 시각적 가독성 향상

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
