### PR TITLE
존재하지 않는 저장소 입력 시 데이터 수집 전 사전 검증 후 종료

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -202,6 +202,19 @@ cli
         pageSize,
       ) as FullGitHubService;
 
+      // 실제 데이터 수집 전에 모든 저장소가 GitHub에 존재하는지 한 번에 검증합니다.
+      const missingRepos =
+        await githubService.validateRepositoriesExist(parsedRepos);
+
+      if (missingRepos.length > 0) {
+        for (const repoPath of missingRepos) {
+          console.error(
+            `오류: 저장소 '${repoPath}'를 찾을 수 없거나 접근할 수 없습니다.`,
+          );
+        }
+        process.exit(1);
+      }
+
       // --claims 옵션이 있으면 점수 계산 대신 이슈 선점 현황만 조회합니다.
       if (isClaimsMode) {
         for (const {repoPath, owner, repoName} of parsedRepos) {

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -256,7 +256,8 @@ export const countByCategory = (
 /**
  * GitHub GraphQL API를 사용하는 서비스 객체를 생성합니다.
  * @param token GitHub Personal Access Token
- * @returns 저장소 상세 데이터와 이슈 선점 현황을 조회하는 서비스 객체
+ * @param pageSize 한 번에 가져올 항목 수 (기본값: 100)
+ * @returns 저장소 상세 데이터, 이슈 선점 현황, 저장소 존재 검증 기능을 제공하는 서비스 객체
  */
 export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
   const githubGraphQL = graphql.defaults({
@@ -899,8 +900,52 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     return {repoPath, claimed, unclaimed};
   };
 
+  /**
+   * 입력된 저장소 목록이 GitHub에 실제로 존재하고 접근 가능한지 한 번의 GraphQL 쿼리로 검증합니다.
+   * 존재하지 않거나 접근할 수 없는 저장소의 repoPath 목록을 반환합니다.
+   * @param repos 검증할 저장소 목록 (owner, repoName, repoPath)
+   * @returns 존재하지 않거나 접근 불가한 저장소 경로 목록
+   */
+  const validateRepositoriesExist = async (
+    repos: {owner: string; repoName: string; repoPath: string}[],
+  ): Promise<string[]> => {
+    const varDefs = repos
+      .map((_, i) => `$o${i}: String!, $n${i}: String!`)
+      .join(', ');
+    const fields = repos
+      .map(
+        (_, i) =>
+          `r${i}: repository(owner: $o${i}, name: $n${i}) { nameWithOwner }`,
+      )
+      .join('\n');
+
+    const query = `query(${varDefs}) {\n${fields}\n}`;
+
+    const variables: Record<string, string> = {};
+    repos.forEach((repo, i) => {
+      variables[`o${i}`] = repo.owner;
+      variables[`n${i}`] = repo.repoName;
+    });
+
+    type ExistenceData = Record<string, {nameWithOwner: string} | null>;
+
+    let data: ExistenceData;
+    try {
+      data = await githubGraphQL<ExistenceData>(query, variables);
+    } catch (error: unknown) {
+      // NOT_FOUND 등 errors가 있어도 부분 데이터는 error.data에 담겨 옴
+      const partial = (error as {data?: ExistenceData}).data;
+      if (!partial) throw error;
+      data = partial;
+    }
+
+    // 응답이 null인 저장소 = 존재하지 않거나 접근 불가
+    return repos.filter((_, i) => !data[`r${i}`]).map(repo => repo.repoPath);
+  };
+
   return {
     getDetailedRepoData,
     getRecentClaimsData,
+    validateRepositoriesExist,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,25 @@ export interface ClaimService {
 }
 
 /**
+ * 저장소 존재 여부 검증을 위한 서비스 인터페이스.
+ */
+export interface RepoValidationService {
+  /**
+   * 입력된 저장소 목록이 GitHub에 실제로 존재하고 접근 가능한지 검증합니다.
+   * 여러 저장소를 하나의 GraphQL 쿼리로 묶어 확인하며,
+   * 존재하지 않거나 접근할 수 없는 저장소의 경로 목록을 반환합니다.
+   * @param repos 검증할 저장소 목록
+   * @returns 존재하지 않거나 접근 불가한 저장소 경로 목록
+   */
+  validateRepositoriesExist(
+    repos: {owner: string; repoName: string; repoPath: string}[],
+  ): Promise<string[]>;
+}
+
+/**
  * 모든 GitHub 서비스 기능을 포함하는 통합 인터페이스.
  * `createGitHubService` 함수가 반환해야 하는 타입입니다.
  */
-export type FullGitHubService = GitHubServiceCore & ClaimService;
+export type FullGitHubService = GitHubServiceCore &
+  ClaimService &
+  RepoValidationService;


### PR DESCRIPTION
### ISSUE_ID
Closes #275 

### 변경사항
- [x] `src/types.ts` — `RepoValidationService` 인터페이스 추가 및 `FullGitHubService` 타입에 교차 적용
- [x] `src/github-service.ts` — `validateRepositoriesExist` 구현 및 반환 객체에 포함
- [x] `index.ts` — 데이터 수집 루프 진입 전 저장소 존재 여부 일괄 검증 단계 추가

### 구현 내용

`parseRepoPath`는 `owner/repo` 형식만 검사하고 실제 존재 여부는 확인하지 않았습니다. 형식이 올바르더라도 존재하지 않거나 접근할 수 없는 저장소가 분석 단계로 넘어갔고, 점수 분석 모드와 `--claims` 모드에서 오류 처리 방식이 달라 일관성이 없었습니다.

이를 해결하기 위해 데이터 수집 시작 전에 모든 저장소의 존재 여부를 GraphQL로 사전 검증하는 단계를 추가했습니다.

- 여러 저장소를 alias로 묶어 **하나의 쿼리**로 일괄 확인합니다.
- `NOT_FOUND` 등 errors가 반환되더라도 `error.data`에서 부분 데이터를 꺼내 어떤 저장소가 누락됐는지 판별합니다.
- 존재하지 않거나 접근 불가한 저장소가 하나라도 있으면 명확한 오류 메시지를 출력하고 `process.exit(1)`로 종료합니다.
- 점수 분석 모드와 `--claims` 모드 모두 동일한 검증 단계를 거칩니다.

### 🧪 테스트 방법

```bash
# 존재하지 않는 저장소 입력 시 조기 종료 확인
bun run index.ts oss2026hnu/reposcore-ts oss2026hnu/nonexistent-repo --token $GITHUB_TOKEN
# 기대 출력: 오류: 저장소 'oss2026hnu/nonexistent-repo'를 찾을 수 없거나 접근할 수 없습니다.

# 정상 저장소는 기존과 동일하게 동작 확인
bun run index.ts oss2026hnu/reposcore-ts --token $GITHUB_TOKEN
```