### PR TITLE
fix: claims 빈 keywords 입력 검증 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Options:
   --sort-by <field>      정렬 기준 (score, id) (default: score)
   --sort-order <order>   정렬 방식 (asc, desc) (default: desc)
   --claims               최근 이슈 선점 현황을 조회합니다 
-  --keywords [items]     이슈 선점 키워드 목록(쉼표 구분) (default: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this)
+  --keywords [items]     이슈 선점 키워드 목록(쉼표 구분, 기본값: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this) 
   --page-size <number>   한 번에 가져올 항목 수 (1~100) (default: $PAGE_SIZE)
   -v, --version          Display version number 
   -h, --help             Display this message

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,31 @@ function parseRepoPath(repoPath: string) {
   };
 }
 
+/**
+ * CLI 원본 인자에서 --keywords 옵션이 명시적으로 입력되었는지와 값을 확인합니다.
+ */
+function getExplicitKeywordsValue(argv: string[]): string | null {
+  const optionIndex = argv.findIndex(
+    arg => arg === '--keywords' || arg.startsWith('--keywords='),
+  );
+
+  if (optionIndex === -1) {
+    return null;
+  }
+
+  const option = argv[optionIndex]!;
+  if (option.startsWith('--keywords=')) {
+    return option.slice('--keywords='.length);
+  }
+
+  const value = argv[optionIndex + 1];
+  if (!value || value.startsWith('-')) {
+    return '';
+  }
+
+  return value;
+}
+
 cli
   .command('[...repos]', '대상 저장소 목록 (예: owner/repo1 owner/repo2)')
   .option('-t, --token <token>', 'GitHub Personal Access Token', {
@@ -116,13 +141,27 @@ cli
         "I'll take this",
       ];
 
-      const claimKeywords =
-        typeof options.keywords === 'string'
+      const explicitKeywordsValue = getExplicitKeywordsValue(process.argv);
+      const rawKeywords =
+        explicitKeywordsValue ??
+        (typeof options.keywords === 'string'
           ? options.keywords
-              .split(',')
-              .map(k => k.trim())
-              .filter(Boolean)
-          : DEFAULT_KEYWORDS;
+          : DEFAULT_KEYWORDS.join(','));
+
+      const claimKeywords = rawKeywords
+        .split(',')
+        .map(k => k.trim())
+        .filter(Boolean);
+
+      if (
+        isClaimsMode &&
+        explicitKeywordsValue !== null &&
+        claimKeywords.length === 0
+      ) {
+        errors.push(
+          '오류: --keywords에는 하나 이상의 선점 키워드를 입력해야 합니다.',
+        );
+      }
 
       const parsedRepos: {
         repoPath: string;

--- a/index.ts
+++ b/index.ts
@@ -41,31 +41,6 @@ function parseRepoPath(repoPath: string) {
   };
 }
 
-/**
- * CLI 원본 인자에서 --keywords 옵션이 명시적으로 입력되었는지와 값을 확인합니다.
- */
-function getExplicitKeywordsValue(argv: string[]): string | null {
-  const optionIndex = argv.findIndex(
-    arg => arg === '--keywords' || arg.startsWith('--keywords='),
-  );
-
-  if (optionIndex === -1) {
-    return null;
-  }
-
-  const option = argv[optionIndex]!;
-  if (option.startsWith('--keywords=')) {
-    return option.slice('--keywords='.length);
-  }
-
-  const value = argv[optionIndex + 1];
-  if (!value || value.startsWith('-')) {
-    return '';
-  }
-
-  return value;
-}
-
 cli
   .command('[...repos]', '대상 저장소 목록 (예: owner/repo1 owner/repo2)')
   .option('-t, --token <token>', 'GitHub Personal Access Token', {
@@ -86,9 +61,13 @@ cli
     default: 'desc',
   })
   .option('--claims', '최근 이슈 선점 현황을 조회합니다')
-  .option('--keywords [items]', '이슈 선점 키워드 목록(쉼표 구분)', {
-    default: "제가 하겠습니다,진행하겠습니다,할게요,I'll take this",
-  })
+  .option(
+    '--keywords [items]',
+    "이슈 선점 키워드 목록(쉼표 구분, 기본값: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this)",
+    {
+      type: [String],
+    },
+  )
   .option('--page-size <number>', '한 번에 가져올 항목 수 (1~100)', {
     default: '$PAGE_SIZE',
   })
@@ -104,7 +83,7 @@ cli
         sortBy: string;
         sortOrder: string;
         claims?: boolean;
-        keywords?: string;
+        keywords?: string | string[];
         pageSize?: number | string;
       },
     ) => {
@@ -141,23 +120,20 @@ cli
         "I'll take this",
       ];
 
-      const explicitKeywordsValue = getExplicitKeywordsValue(process.argv);
-      const rawKeywords =
-        explicitKeywordsValue ??
-        (typeof options.keywords === 'string'
+      const rawKeywords = Array.isArray(options.keywords)
+        ? options.keywords.join(',')
+        : typeof options.keywords === 'string'
           ? options.keywords
-          : DEFAULT_KEYWORDS.join(','));
+          : DEFAULT_KEYWORDS.join(',');
 
       const claimKeywords = rawKeywords
         .split(',')
         .map(k => k.trim())
-        .filter(Boolean);
+        .filter(
+          keyword => keyword && keyword !== 'undefined' && keyword !== '0',
+        );
 
-      if (
-        isClaimsMode &&
-        explicitKeywordsValue !== null &&
-        claimKeywords.length === 0
-      ) {
+      if (isClaimsMode && claimKeywords.length === 0) {
         errors.push(
           '오류: --keywords에는 하나 이상의 선점 키워드를 입력해야 합니다.',
         );

--- a/index.ts
+++ b/index.ts
@@ -120,18 +120,21 @@ cli
         "I'll take this",
       ];
 
-      const rawKeywords = Array.isArray(options.keywords)
-        ? options.keywords.join(',')
-        : typeof options.keywords === 'string'
-          ? options.keywords
-          : DEFAULT_KEYWORDS.join(',');
+      const rawKeywords =
+        Array.isArray(options.keywords) &&
+        options.keywords.length === 1 &&
+        options.keywords[0] === 'undefined'
+          ? DEFAULT_KEYWORDS.join(',')
+          : Array.isArray(options.keywords)
+            ? options.keywords.join(',')
+            : typeof options.keywords === 'string'
+              ? options.keywords
+              : DEFAULT_KEYWORDS.join(',');
 
       const claimKeywords = rawKeywords
         .split(',')
         .map(k => k.trim())
-        .filter(
-          keyword => keyword && keyword !== 'undefined' && keyword !== '0',
-        );
+        .filter(keyword => keyword && keyword !== '0');
 
       if (isClaimsMode && claimKeywords.length === 0) {
         errors.push(


### PR DESCRIPTION
### ISSUE_ID

- close #270

### 변경 사항

리뷰 반영으로 `process.argv` 직접 파싱과 `cli.rawArgs` 확인 로직을 제거하고, cac 옵션 설정과 `options.keywords` 값만 사용하도록 수정했습니다.

- `process.argv` 직접 참조 제거
- `getExplicitKeywordsValue()` 제거
- `cli.rawArgs` 사용 제거
- `--keywords [items]` 옵션에 `type: [String]` 설정 적용
- `--keywords` 생략 시 기본 키워드 사용
- `--keywords ""` 입력 시 오류 처리
- `--keywords ",,,"` 입력 시 오류 처리
- 중복 오류 메시지 출력 제거

### 확인 사항

```bash
npm run lint
npm test
npm run typecheck

bun run index.ts oss2026hnu/reposcore-ts --claims --token dummy
echo "exit=$?"

bun run index.ts oss2026hnu/reposcore-ts --claims --token dummy --keywords ""
echo "exit=$?"

bun run index.ts oss2026hnu/reposcore-ts --claims --token dummy --keywords ",,,"
echo "exit=$?"