### PR TITLE
fix: 문서 검증 워크플로우 paths 필터 수정

### DIFF
--- a/.github/workflows/docs-synopsis-validation.yml
+++ b/.github/workflows/docs-synopsis-validation.yml
@@ -3,13 +3,15 @@ name: Docs Synopsis Validation
 on:
   pull_request:
     paths:
-      - "tools/update-synopsis.py"
-      - "tools/j2render.py"
+      - "README.md"
+      - "README-template.md"
       - "index.ts"
+      - "Makefile"
       - "package.json"
       - "bun.lock"
-      - "Makefile"
-      - "README-template.md.j2"
+      - "tools/build-synopsis-data.py"
+      - "tools/build-docs-data.py"
+      - "docs/*.md"
 
 jobs:
   verify-docs-synopsis:


### PR DESCRIPTION
### ISSUE_ID

- close #278

### 변경 사항

문서 검증 워크플로우의 `paths` 필터가 실제 존재하지 않는 파일을 가리키던 문제를 수정했습니다.

- `tools/update-synopsis.py` 제거
- `tools/j2render.py` 제거
- `README-template.md.j2` 제거
- `README.md` 추가
- `README-template.md` 추가
- `tools/build-synopsis-data.py` 추가
- `tools/build-docs-data.py` 추가
- `docs/*.md` 추가
- `index.ts`, `Makefile`, `package.json`, `bun.lock` 변경 시에도 문서 검증이 실행되도록 유지

### 확인 사항

```bash
npm test
npm run typecheck