### PR TITLE
devcontainer postCreateCommand에 requirements.txt 파이썬 의존성 자동 설치 추가

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,6 @@
       ]
     }
   },
-  "postCreateCommand": "curl -fsSL https://bun.sh/install | bash && echo 'export BUN_INSTALL=\"$HOME/.bun\"' >> ~/.bashrc && echo 'export PATH=\"$HOME/.bun/bin:$PATH\"' >> ~/.bashrc"
+  // [개선] Bun 설치가 완료된 후, 파이썬 문서 빌드용 의존성(requirements.txt)도 일괄 자동 설치되도록 체이닝 추가
+  "postCreateCommand": "curl -fsSL https://bun.sh/install | bash && echo 'export BUN_INSTALL=\"$HOME/.bun\"' >> ~/.bashrc && echo 'export PATH=\"$HOME/.bun/bin:$PATH\"' >> ~/.bashrc && pip install -r requirements.txt"
 }


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #290 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 **postCreateCommand 의존성 체이닝 확장**: `.devcontainer/devcontainer.json` 내부의 컨테이너 초기화 명령어에 `&& pip install -r requirements.txt` 구조를 안전하게 연쇄 추가했습니다.
- [ ] 변경 사항 2 **문서 자동화 빌드 환경 원클릭 개선**: Codespaces 환경 생성 시 Bun 개발 환경 구축과 동시에 파이썬 `jinja2-cli` 기반의 문서 빌드 의존성이 밑바닥부터 완전 자동으로 구성되도록 설계했습니다.
- [ ] 변경 사항 3 **새로운 기여자 온보딩 편의성 향상**: 새로운 개발자가 매번 수동으로 파이썬 모듈을 설치해야 했던 번거로움을 완전히 해결하고, 초기 진입 후 즉시 `make docs` 및 `make synopsis` 파이프라인을 온전하게 구동할 수 있도록 결함을 보완했습니다.

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
