### PR TITLE
점수 한도 계산 로직 단일화 통합 ( output.ts, score-calculator.ts)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -219,15 +219,17 @@ cli
 
       // --claims 옵션이 있으면 점수 계산 대신 이슈 선점 현황만 조회합니다.
       if (isClaimsMode) {
-        const claimTasks = parsedRepos.map(async ({repoPath, owner, repoName}) => {
-          return await githubService.getRecentClaimsData(
-            owner,
-            repoName,
-            claimKeywords,
-            repoPath,
-            useCache,
-          );
-        });
+        const claimTasks = parsedRepos.map(
+          async ({repoPath, owner, repoName}) => {
+            return await githubService.getRecentClaimsData(
+              owner,
+              repoName,
+              claimKeywords,
+              repoPath,
+              useCache,
+            );
+          },
+        );
 
         const claimResults = await Promise.allSettled(claimTasks);
         let hasClaimFailure = false;
@@ -238,8 +240,13 @@ cli
             printClaims(result.value);
           } else {
             hasClaimFailure = true;
-            const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-            console.error(`오류: '${repoPath}'의 선점 현황을 조회할 수 없습니다. (${msg})`);
+            const msg =
+              result.reason instanceof Error
+                ? result.reason.message
+                : String(result.reason);
+            console.error(
+              `오류: '${repoPath}'의 선점 현황을 조회할 수 없습니다. (${msg})`,
+            );
           }
         });
 
@@ -261,7 +268,11 @@ cli
           {since},
         );
 
-        const repoData = ScoreCalculator.calculateRepoData(detailed, owner, repoName);
+        const repoData = ScoreCalculator.calculateRepoData(
+          detailed,
+          owner,
+          repoName,
+        );
         const repoSummary = summarizeRepo(repoPath, detailed);
 
         const singleUserScores = sortUserScores(
@@ -294,14 +305,19 @@ cli
         if (result.status === 'fulfilled') {
           const {repoData, repoSummary, written} = result.value;
           repoDataList.push(repoData);
-          summaries: repoSummaries.push(repoSummary);
+          repoSummaries.push(repoSummary);
 
           console.log(`[${repoPath}] CSV 저장: ${written.csv}`);
-          if (written.txt) console.log(`[${repoPath}] TXT 저장: ${written.txt}`);
-          if (written.html) console.log(`[${repoPath}] HTML 저장: ${written.html}`);
+          if (written.txt)
+            console.log(`[${repoPath}] TXT 저장: ${written.txt}`);
+          if (written.html)
+            console.log(`[${repoPath}] HTML 저장: ${written.html}`);
         } else {
           hasFailure = true;
-          const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+          const reason =
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
           console.error(`오류: '${repoPath}'의 데이터를 가져올 수 없습니다.`);
           console.error(`상세 원인: ${reason}`);
         }

--- a/src/output.ts
+++ b/src/output.ts
@@ -194,36 +194,35 @@ export const buildUserScoresTxt = (
       `${totalPrs} (${row.prDocs}/${row.prFeatureBug}/${row.prTypo})`,
     ]);
 
-    const maxAdditionalPr = 3 * Math.max(row.prFeatureBug, 1);
+    const limits = ScoreCalculator.calculateLimits(row);
     const totalDocTypoPr = row.prDocs + row.prTypo;
-    const rejectedPr = Math.max(0, totalDocTypoPr - maxAdditionalPr);
-    const validPrCount =
-      row.prFeatureBug + Math.min(totalDocTypoPr, maxAdditionalPr);
-    const maxIssueCount = 4 * validPrCount;
-    const rejectedIssue = Math.max(0, totalIssues - maxIssueCount);
+    const rejectedPr = Math.max(0, totalDocTypoPr - limits.maxAdditionalPr);
+    const rejectedIssue = Math.max(0, totalIssues - limits.maxIssueCount);
 
     if (rejectedPr > 0 || rejectedIssue > 0) {
       const userRejections = [
         `${row.userId}:`,
-        `    [미인정 항목] 문서/오타 PR ${rejectedPr}개 초과(한도 ${maxAdditionalPr}개) / 이슈 ${rejectedIssue}개 초과(한도 ${maxIssueCount}개)`,
+        `    [미인정 항목] 문서/오타 PR ${rejectedPr}개 초과(한도 ${limits.maxAdditionalPr}개) / 이슈 ${rejectedIssue}개 초과(한도 ${limits.maxIssueCount}개)`,
       ];
 
       if (rejectedPr > 0) {
-        const docSuggestionCount = Math.ceil(rejectedPr / 3);
+        const docRatio = ScoreCalculator.MAX_DOCS_TYPO_PR_RATIO;
+        const docSuggestionCount = Math.ceil(rejectedPr / docRatio);
         userRejections.push(
-          `    [추가 제안] 기능/버그 PR ${docSuggestionCount}개 추가 시 문서PR 인정 한도 +${docSuggestionCount * 3}`,
+          `    [추가 제안] 기능/버그 PR ${docSuggestionCount}개 추가 시 문서PR 인정 한도 +${docSuggestionCount * docRatio}`,
         );
       }
 
       if (rejectedIssue > 0) {
-        const issueSuggestionCount = Math.ceil(rejectedIssue / 4);
-        if (totalDocTypoPr < maxAdditionalPr) {
+        const issueRatio = ScoreCalculator.MAX_ISSUE_RATIO;
+        const issueSuggestionCount = Math.ceil(rejectedIssue / issueRatio);
+        if (totalDocTypoPr < limits.maxAdditionalPr) {
           userRejections.push(
-            `    [추가 제안] 문서 PR ${issueSuggestionCount}개 추가 혹은 기능/버그 PR ${issueSuggestionCount}개 추가시 이슈 인정한도 +${issueSuggestionCount * 4}`,
+            `    [추가 제안] 문서 PR ${issueSuggestionCount}개 추가 혹은 기능/버그 PR ${issueSuggestionCount}개 추가시 이슈 인정한도 +${issueSuggestionCount * issueRatio}`,
           );
         } else {
           userRejections.push(
-            `    [추가 제안] 기능/버그 PR ${issueSuggestionCount}개 추가시 이슈 인정한도 +${issueSuggestionCount * 4}`,
+            `    [추가 제안] 기능/버그 PR ${issueSuggestionCount}개 추가시 이슈 인정한도 +${issueSuggestionCount * issueRatio}`,
           );
         }
       }

--- a/src/score-calculator.ts
+++ b/src/score-calculator.ts
@@ -31,6 +31,15 @@ export interface UserScore {
 }
 
 /**
+ * 점수 산정 시 적용되는 한도 계산 결과입니다.
+ */
+export interface ScoreLimits {
+  maxAdditionalPr: number;
+  validPrCount: number;
+  maxIssueCount: number;
+}
+
+/**
  * 저장소의 이슈와 PR 데이터를 기반으로 사용자별 기여 점수를 계산하는 클래스입니다.
  */
 export class ScoreCalculator {
@@ -39,6 +48,9 @@ export class ScoreCalculator {
   private static readonly PR_TYPO_WEIGHT = 1;
   private static readonly ISSUE_FEATURE_BUG_WEIGHT = 2;
   private static readonly ISSUE_DOCS_WEIGHT = 1;
+
+  public static readonly MAX_DOCS_TYPO_PR_RATIO = 3;
+  public static readonly MAX_ISSUE_RATIO = 4;
 
   /**
    * 저장소의 이슈와 PR 데이터를 사용자별 점수 계산 데이터로 변환합니다.
@@ -116,30 +128,22 @@ export class ScoreCalculator {
   }
 
   /**
-   * 주어진 사용자 기여 데이터에서 점수 산정에 반영할 유효 PR 개수를 계산합니다.
+   * 사용자별 기여 데이터에서 점수 산정 한도를 계산합니다.
    *
-   * @param data 사용자별 이슈와 PR 기여 데이터
-   * @returns 점수 산정에 반영되는 유효 PR 개수
+   * @param data 사용자별 이슈와 PR 기여 데이터 (필요 필드만)
+   * @returns 한도 계산 결과 (문서/오타 PR 최대 한도, 유효 PR 개수, 최대 인정 이슈 개수)
    */
-  private static calculateValidPrCount(data: IssuePrData): number {
-    const pFb = data.prFeatureBug;
-    const pDocsAndTypo = data.prDocs + data.prTypo;
-    return pFb + Math.min(pDocsAndTypo, 3 * Math.max(pFb, 1));
-  }
+  public static calculateLimits(
+    data: Pick<IssuePrData, 'prFeatureBug' | 'prDocs' | 'prTypo'>,
+  ): ScoreLimits {
+    const maxAdditionalPr =
+      ScoreCalculator.MAX_DOCS_TYPO_PR_RATIO * Math.max(data.prFeatureBug, 1);
+    const totalDocTypoPr = data.prDocs + data.prTypo;
+    const validPrCount =
+      data.prFeatureBug + Math.min(totalDocTypoPr, maxAdditionalPr);
+    const maxIssueCount = ScoreCalculator.MAX_ISSUE_RATIO * validPrCount;
 
-  /**
-   * 사용자 기여 데이터와 유효 PR 개수를 기반으로 점수 산정에 반영할 유효 이슈 개수를 계산합니다.
-   *
-   * @param data 사용자별 이슈와 PR 기여 데이터
-   * @param validPrCount 점수 산정에 반영되는 유효 PR 개수
-   * @returns 점수 산정에 반영되는 유효 이슈 개수
-   */
-  private static calculateValidIssueCount(
-    data: IssuePrData,
-    validPrCount: number,
-  ): number {
-    const totalIssues = data.issueFeatureBug + data.issueDocs;
-    return Math.min(totalIssues, 4 * validPrCount);
+    return {maxAdditionalPr, validPrCount, maxIssueCount};
   }
 
   /**
@@ -149,10 +153,11 @@ export class ScoreCalculator {
    * @returns 계산된 최종 기여 점수
    */
   private static calculateFinalScore(data: IssuePrData): number {
-    const validPrCount = ScoreCalculator.calculateValidPrCount(data);
-    const validIssueCount = ScoreCalculator.calculateValidIssueCount(
-      data,
-      validPrCount,
+    const limits = ScoreCalculator.calculateLimits(data);
+    const validPrCount = limits.validPrCount;
+    const validIssueCount = Math.min(
+      data.issueFeatureBug + data.issueDocs,
+      limits.maxIssueCount,
     );
 
     const acceptedPrFeatureBug = Math.min(data.prFeatureBug, validPrCount);


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #291 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] ScoreLimits 인터페이스를 도입
- [ ] 점수 한도 계산 로직을 ScoreCalculator.calculateLimits 메서드 한 곳으로 모아 output.ts와 중복되던 코드를 제거
- [ ] 점수 한도 계산에 쓰이는 값들을 상수화 진행

### 🧪 테스트 방법 (선택 사항)
아래 명령어 실행 후 txt 파일이 정상적인지 확인

bun run index.ts oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts oss2026hnu/reposcore-py --token {토큰} --format=txt

### 💬 참고 사항 (선택 사항)

