### PR TITLE
fix: 빈 --format 입력 검증 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -155,6 +155,12 @@ cli
         );
       }
 
+      if (formats.length === 0) {
+        errors.push(
+          '오류: --format에는 csv, txt, html 중 하나 이상의 출력 형식을 입력하세요.',
+        );
+      }
+
       const invalidFormats = formats.filter(
         format => !supportedFormats.includes(format as SupportedFormat),
       );


### PR DESCRIPTION
# ISSUE_ID
Closes #303

### 변경사항
- [x] `--format ",,,"`처럼 쉼표만 입력된 경우를 검증하도록 수정했습니다.
- [x] 정규화 후 출력 형식 목록이 비어 있으면 오류 메시지를 출력하고 종료하도록 했습니다.
- [x] 기존 `csv`, `txt`, `html`, `csv,txt` 출력 동작은 유지했습니다.

### 🧪 테스트 방법 (선택 사항)

아래 명령어로 동작을 확인했습니다.

```bash
bun run index.ts oss2026hnu/reposcore-ts --format ",,,"
bun run index.ts oss2026hnu/reposcore-ts --format csv
bun run index.ts oss2026hnu/reposcore-ts --format csv,txt
bun run index.ts oss2026hnu/reposcore-ts --format abc
bun run typecheck
bun test
bun run lint
```

`--format ",,,"` 입력 시 다음 오류가 출력되는 것을 확인했습니다.

```text
오류: --format에는 csv, txt, html 중 하나 이상의 출력 형식을 입력하세요.
```

### 💬 참고 사항 (선택 사항)

이 PR은 `--format`의 다중 출력 기능을 변경하지 않고, 유효한 출력 형식이 하나도 남지 않는 입력만 명확히 검증하도록 개선합니다.