### PR TITLE
실행 진행·캐시 진단 로그가 항상 출력되어 핵심 결과와 섞임 --verbose 옵션으로 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Options:
   --claims               최근 이슈 선점 현황을 조회합니다 
   --keywords [items]     이슈 선점 키워드 목록(쉼표 구분, 기본값: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this) 
   --page-size <number>   한 번에 가져올 항목 수 (1~100) (default: $PAGE_SIZE)
+  --verbose              진단 및 진행 로그를 출력합니다 
   -v, --version          Display version number 
   -h, --help             Display this message
 ```

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import {
   type SupportedSortOrder,
 } from './src/sort';
 import {type FullGitHubService} from './src/types';
+import {setVerbose, logVerbose} from './src/logger';
 
 const cli = cac('reposcore-ts');
 cli.version(pkg.version);
@@ -71,6 +72,7 @@ cli
   .option('--page-size <number>', '한 번에 가져올 항목 수 (1~100)', {
     default: '$PAGE_SIZE',
   })
+  .option('--verbose', '진단 및 진행 로그를 출력합니다')
   .action(
     async (
       repos: string[],
@@ -85,8 +87,10 @@ cli
         claims?: boolean;
         keywords?: string | string[];
         pageSize?: number | string;
+        verbose?: boolean;
       },
     ) => {
+      setVerbose(!!options.verbose);
       // CLI 옵션값을 내부에서 사용할 형태로 정규화합니다.
       const token =
         options.token === '$GITHUB_TOKEN'
@@ -273,8 +277,8 @@ cli
         return;
       }
 
-      console.log(`형식: ${formats.join(', ')}`);
-      console.log(`저장소: ${repos.join(', ')}`);
+      logVerbose(`형식: ${formats.join(', ')}`);
+      logVerbose(`저장소: ${repos.join(', ')}`);
 
       // ── [개선] 일반 기여도 점수 산정 모드 병렬 처리 (Promise.allSettled) ──────
       const tasks = parsedRepos.map(async ({repoPath, owner, repoName}) => {
@@ -324,11 +328,11 @@ cli
           repoDataList.push(repoData);
           repoSummaries.push(repoSummary);
 
-          console.log(`[${repoPath}] CSV 저장: ${written.csv}`);
+          logVerbose(`[${repoPath}] CSV 저장: ${written.csv}`);
           if (written.txt)
-            console.log(`[${repoPath}] TXT 저장: ${written.txt}`);
+            logVerbose(`[${repoPath}] TXT 저장: ${written.txt}`);
           if (written.html)
-            console.log(`[${repoPath}] HTML 저장: ${written.html}`);
+            logVerbose(`[${repoPath}] HTML 저장: ${written.html}`);
         } else {
           hasFailure = true;
           const reason =
@@ -361,12 +365,12 @@ cli
         },
         outputDir,
       );
-      console.log(`[합산] CSV 저장: ${written.csv}`);
+      console.error(`[합산] CSV 저장: ${written.csv}`);
       if (written.txt) {
-        console.log(`[합산] TXT 저장: ${written.txt}`);
+        console.error(`[합산] TXT 저장: ${written.txt}`);
       }
       if (written.html) {
-        console.log(`[합산] HTML 저장: ${written.html}`);
+        console.error(`[합산] HTML 저장: ${written.html}`);
       }
     },
   );

--- a/index.ts
+++ b/index.ts
@@ -91,6 +91,7 @@ cli
       },
     ) => {
       setVerbose(!!options.verbose);
+
       // CLI 옵션값을 내부에서 사용할 형태로 정규화합니다.
       const token =
         options.token === '$GITHUB_TOKEN'
@@ -329,8 +330,7 @@ cli
           repoSummaries.push(repoSummary);
 
           logVerbose(`[${repoPath}] CSV 저장: ${written.csv}`);
-          if (written.txt)
-            logVerbose(`[${repoPath}] TXT 저장: ${written.txt}`);
+          if (written.txt) logVerbose(`[${repoPath}] TXT 저장: ${written.txt}`);
           if (written.html)
             logVerbose(`[${repoPath}] HTML 저장: ${written.html}`);
         } else {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,25 @@
+/**
+ * CLI 로깅 상태를 관리하고 출력하는 헬퍼 모듈입니다.
+ */
+
+let verboseEnabled = false;
+
+/**
+ * 진단 및 진행 로그의 출력 여부를 설정합니다.
+ *
+ * @param verbose true이면 진단 로그가 출력됩니다.
+ */
+export const setVerbose = (verbose: boolean): void => {
+  verboseEnabled = verbose;
+};
+
+/**
+ * verbose 모드가 활성화되었을 때만 표준 에러(stderr)로 로그를 출력합니다.
+ *
+ * @param args 출력할 메시지나 객체
+ */
+export const logVerbose = (...args: unknown[]): void => {
+  if (verboseEnabled) {
+    console.error(...args);
+  }
+};


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #308 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] **로깅 헬퍼 모듈 추가 (`src/logger.ts`)**
   - `setVerbose` 함수로 로깅 상태를 설정하고, `logVerbose` 함수를 통해 `verbose`가 활성화되었을 때만 `stderr`(표준 에러)로 로그를 출력하도록 구현했습니다.
   - 모듈 레벨에서 상태를 관리하므로, `cache.ts` 등 CLI 옵션을 직접 받지 않는 파일에서도 함수 인자 수정 없이 쉽게 로깅 상태를 공유할 수 있습니다.
- [ ] **CLI 옵션 추가 및 적용 (`index.ts`)**
   - `--verbose` 불리언 플래그를 추가했습니다 (기본값: false).
   - CLI 옵션 파싱 직후 `setVerbose(!!options.verbose)`를 호출하여 상태를 초기화합니다.
   - 진단 목적의 로그(형식, 저장소 목록 안내 및 개별 저장소의 CSV/TXT/HTML 처리 경로)를 `console.log`에서 `logVerbose`로 교체했습니다.
- [ ] **출력 스트림(stdout/stderr) 격리 (`index.ts`)**
   - `stdout`(표준 출력)에는 `--claims` 명령의 실행 결과 등 순수 데이터만 남도록 설계했습니다.
   - 진단 로그는 `logVerbose`를 통해 `stderr`로 빠지며, 항상 출력해야 하는 최종 합산 파일 저장 경로 역시 `console.error`를 사용하여 `stderr`로 옮겼습니다.


### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
기본 상태에서는 상세한 진행 로그가 출력되지 않고, 오류 메시지와 최종 결과물 경로만 노출되어야 합니다.

```bash
bun run index.ts oss2026hnu/reposcore-ts
```
**기대 결과:** 형식, 저장소 목록, 저장소별 개별 처리 경로는 보이지 않고, `[합산] CSV 저장: output/...` 등 최종 경로 로그만 표시됩니다.

문제를 추적하거나 진행 상황을 볼 때 사용하는 옵션입니다.

```bash
bun run index.ts oss2026hnu/reposcore-ts --verbose
```
**기대 결과:** `형식: csv`, `저장소: oss2026hnu/reposcore-ts`, `[oss2026hnu/reposcore-ts] CSV 저장: ...` 등의 상세한 과정이 모두 출력됩니다.



### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
