### PR TITLE
claims 출력 모드에 issue와 user 모드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
   --since <since>        캐시 이후 증분 수집 기준 시점 ISO8601 
   --sort-by <field>      정렬 기준 (score, id) (default: score)
   --sort-order <order>   정렬 방식 (asc, desc) (default: desc)
-  --claims               최근 이슈 선점 현황을 조회합니다 
+  --claims [issue|user]  최근 이슈 선점 현황 조회 (기본 issue) 
   --keywords [items]     이슈 선점 키워드 목록(쉼표 구분, 기본값: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this) 
   --page-size <number>   한 번에 가져올 항목 수 (1~100) (default: $PAGE_SIZE)
   --verbose              진단 및 진행 로그를 출력합니다 

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ cli
   .option('--sort-order <order>', '정렬 방식 (asc, desc)', {
     default: 'desc',
   })
-  .option('--claims', '최근 이슈 선점 현황을 조회합니다')
+  .option('--claims [issue|user]', '최근 이슈 선점 현황 조회 (기본 issue)')
   .option(
     '--keywords [items]',
     "이슈 선점 키워드 목록(쉼표 구분, 기본값: 제가 하겠습니다,진행하겠습니다,할게요,I'll take this)",
@@ -84,7 +84,7 @@ cli
         since?: string;
         sortBy: string;
         sortOrder: string;
-        claims?: boolean;
+        claims?: boolean | string;
         keywords?: string | string[];
         pageSize?: number | string;
         verbose?: boolean;
@@ -116,7 +116,12 @@ cli
 
       const errors: string[] = [];
 
-      const isClaimsMode = !!options.claims;
+      const isClaimsMode = options.claims !== undefined;
+      const claimsMode =
+        typeof options.claims === 'string'
+          ? options.claims.toLowerCase()
+          : 'issue';
+
       // 이슈 선점 여부를 판단하기 위한 기본 키워드 목록입니다.
       const DEFAULT_KEYWORDS = [
         '제가 하겠습니다',
@@ -144,6 +149,12 @@ cli
       if (isClaimsMode && claimKeywords.length === 0) {
         errors.push(
           '오류: --keywords에는 하나 이상의 선점 키워드를 입력해야 합니다.',
+        );
+      }
+
+      if (isClaimsMode && claimsMode !== 'issue' && claimsMode !== 'user') {
+        errors.push(
+          `오류: 지원하지 않는 --claims 모드 '${options.claims}'입니다. issue 또는 user를 입력하세요.`,
         );
       }
 
@@ -262,7 +273,7 @@ cli
               repoPath,
               useCache,
             );
-            printClaims(claims);
+            printClaims(claims, claimsMode as 'issue' | 'user');
           } catch (err) {
             hasClaimFailure = true;
             const msg = err instanceof Error ? err.message : String(err);

--- a/src/output.ts
+++ b/src/output.ts
@@ -444,8 +444,12 @@ const getDeadlineStatus = (
  * 선점 현황 데이터를 표준 출력(stdout)에 사람이 읽기 좋은 형태로 출력합니다.
  *
  * @param claims 저장소별 선점 및 미선점 이슈 정보
+ * @param mode 출력 모드 ('issue' 또는 'user')
  */
-export const printClaims = (claims: RepoClaims): void => {
+export const printClaims = (
+  claims: RepoClaims,
+  mode: 'issue' | 'user' = 'issue',
+): void => {
   console.log(`\n[${claims.repoPath}]`);
 
   // 1. 원본 배열을 변경하지 않도록 복사([...]) 후 issueNumber 오름차순 정렬
@@ -457,26 +461,56 @@ export const printClaims = (claims: RepoClaims): void => {
     (a, b) => a.issueNumber - b.issueNumber,
   );
 
-  console.log('선점된 이슈');
+  console.log(mode === 'user' ? '선점된 이슈 (사용자별)' : '선점된 이슈');
   if (sortedClaimed.length === 0) {
     console.log('  (없음)');
   } else {
-    // 2. 기존 claims.claimed 대신 정렬된 sortedClaimed 배열을 순회하도록 변경
-    for (const c of sortedClaimed) {
-      console.log(`- #${c.issueNumber} ${c.title}`);
-      console.log(`  URL: ${c.url}`);
-      if (c.claimedAt) {
-        const {type, hours} = getTaskDeadline(c.labels);
-        const status = getDeadlineStatus(
-          c.claimedAt,
-          hours,
-          c.linkedPrNumber,
-          c.linkedPrUrl,
-        );
-        console.log(`  선점자: ${c.claimedBy}`);
-        console.log(`  상태: ${type} [${hours}시간 기한] | ${status}`);
-      } else {
-        console.log(`  선점자: ${c.claimedBy}`);
+    if (mode === 'user') {
+      const byUser = new Map<string, typeof sortedClaimed>();
+      for (const c of sortedClaimed) {
+        const user = c.claimedBy || 'unknown';
+        if (!byUser.has(user)) {
+          byUser.set(user, []);
+        }
+        byUser.get(user)!.push(c);
+      }
+
+      const sortedUsers = Array.from(byUser.keys()).sort();
+
+      for (const user of sortedUsers) {
+        console.log(`\n[${user}]`);
+        for (const c of byUser.get(user)!) {
+          console.log(`- #${c.issueNumber} ${c.title}`);
+          console.log(`  URL: ${c.url}`);
+          if (c.claimedAt) {
+            const {type, hours} = getTaskDeadline(c.labels);
+            const status = getDeadlineStatus(
+              c.claimedAt,
+              hours,
+              c.linkedPrNumber,
+              c.linkedPrUrl,
+            );
+            console.log(`  상태: ${type} [${hours}시간 기한] | ${status}`);
+          }
+        }
+      }
+    } else {
+      for (const c of sortedClaimed) {
+        console.log(`- #${c.issueNumber} ${c.title}`);
+        console.log(`  URL: ${c.url}`);
+        if (c.claimedAt) {
+          const {type, hours} = getTaskDeadline(c.labels);
+          const status = getDeadlineStatus(
+            c.claimedAt,
+            hours,
+            c.linkedPrNumber,
+            c.linkedPrUrl,
+          );
+          console.log(`  선점자: ${c.claimedBy}`);
+          console.log(`  상태: ${type} [${hours}시간 기한] | ${status}`);
+        } else {
+          console.log(`  선점자: ${c.claimedBy}`);
+        }
       }
     }
   }

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -163,4 +163,65 @@ describe('선점 기한 판정', () => {
     expect(joined).toContain('상태: 문서 [24시간 기한]');
     expect(joined).toContain('상태: 코드 [48시간 기한]');
   });
+
+  test('사용자별로 묶어 선점 현황을 출력해야 한다 (user 모드)', () => {
+    const claims: RepoClaims = {
+      repoPath: 'oss2026hnu/reposcore-ts',
+      claimed: [
+        {
+          issueNumber: 101,
+          title: 'Issue 101',
+          url: 'https://example.com/issues/101',
+          labels: {nodes: []},
+          claimedBy: 'alpha',
+          matchedKeyword: '/claim',
+          claimedAt: '2026-06-12T00:00:00.000Z',
+          linkedPrNumber: null,
+          linkedPrUrl: null,
+        },
+        {
+          issueNumber: 103,
+          title: 'Issue 103',
+          url: 'https://example.com/issues/103',
+          labels: {nodes: []},
+          claimedBy: 'alpha',
+          matchedKeyword: '/claim',
+          claimedAt: '2026-06-12T00:00:00.000Z',
+          linkedPrNumber: null,
+          linkedPrUrl: null,
+        },
+        {
+          issueNumber: 102,
+          title: 'Issue 102',
+          url: 'https://example.com/issues/102',
+          labels: {nodes: []},
+          claimedBy: 'beta',
+          matchedKeyword: '/claim',
+          claimedAt: null,
+          linkedPrNumber: null,
+          linkedPrUrl: null,
+        },
+      ],
+      unclaimed: [],
+    };
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(value => String(value)).join(' '));
+    };
+
+    try {
+      printClaims(claims, 'user');
+    } finally {
+      console.log = originalLog;
+    }
+
+    const joined = logs.join('\n');
+    expect(joined).toContain('[alpha]');
+    expect(joined).toContain('- #101 Issue 101');
+    expect(joined).toContain('- #103 Issue 103');
+    expect(joined).toContain('[beta]');
+    expect(joined).toContain('- #102 Issue 102');
+  });
 });


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #309 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] index.ts에서 --claims 옵션을 확장하여 issue 또는 user 모드 값을 받을 수 있도록 파싱 및 검증 로직 추가 (기본값: issue)
- [ ] output.ts의 printClaims 함수를 개선하여, user 모드 입력 시 선점된 이슈를 사용자 기준으로 묶어 출력하도록 구현
- [ ] tests/output.test.ts에 사용자별 선점 현황 그룹화가 정상적으로 동작하는지 확인하는 단위 테스트 추가

### 🧪 테스트 방법 (선택 사항)
bun run index.ts oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts oss2026hnu/reposcore-py --token {토큰} --claims user

bun run index.ts oss2026hnu/reposcore-cs oss2026hnu/reposcore-ts oss2026hnu/reposcore-py --token {토큰} --claims

위 두명령어를 실행하여 정상 동작하는지 확인

### 💬 참고 사항 (선택 사항)

