### PR TITLE
 claims 증분 조회에서 --page-size가 반영

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -751,7 +751,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
           `,
           {
             searchQuery: `repo:${owner}/${repo} is:issue updated:>=${since}`,
-            pageSize: PAGE_SIZE,
+            pageSize,
             cursor,
           },
         );


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/311

### 변경사항
- [x] getUpdatedIssuesWithComments()에서 GraphQL 요청 시 고정 상수 PAGE_SIZE 대신 클로저 변수 pageSize를 사용하도록 수정
- [x] --page-size 옵션이 claims 증분 조회 경로에도 정상 반영되도록 수정

### 🧪 테스트 방법 (선택 사항)
1. bun run index.ts oss2026hnu/reposcore-ts --claims 실행하여 claims 캐시 생성
2. bun run index.ts oss2026hnu/reposcore-ts --claims --page-size 30 실행
3. 수정 전: GraphQL 요청의 pageSize가 100으로 고정되는 것을 확인
4. 수정 후: GraphQL 요청의 pageSize가 30으로 반영되는 것을 확인

### 💬 참고 사항 (선택 사항)