### PR TITLE
CLI 캐시 옵션(--cache) 처리 방식 정석화 및 도움말 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Options:
   -t, --token <token>    GitHub Personal Access Token (default: $GITHUB_TOKEN)
   -f, --format <format>  출력 형식 (csv, txt, html) (default: csv)
   --output-dir <path>    결과 파일을 저장할 디렉터리 (default: output)
-  --no-cache             설정 시 기존 캐시를 무시하고 전체 데이터를 새로 수집합니다
+  --cache                기존 캐시를 사용하여 데이터를 수집합니다 (캐시 무시: --no-cache) (default: true)
   --since <since>        캐시 이후 증분 수집 기준 시점 ISO8601 
   --sort-by <field>      정렬 기준 (score, id) (default: score)
   --sort-order <order>   정렬 방식 (asc, desc) (default: desc)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Options:
   -t, --token <token>    GitHub Personal Access Token (default: $GITHUB_TOKEN)
   -f, --format <format>  출력 형식 (csv, txt, html) (default: csv)
   --output-dir <path>    결과 파일을 저장할 디렉터리 (default: output)
-  --no-cache             캐시를 무시하고 GitHub API를 새로 호출합니다 (default: true)
+  --no-cache             설정 시 기존 캐시를 무시하고 전체 데이터를 새로 수집합니다
   --since <since>        캐시 이후 증분 수집 기준 시점 ISO8601 
   --sort-by <field>      정렬 기준 (score, id) (default: score)
   --sort-order <order>   정렬 방식 (asc, desc) (default: desc)

--- a/index.ts
+++ b/index.ts
@@ -52,7 +52,10 @@ cli
   .option('--output-dir <path>', '결과 파일을 저장할 디렉터리', {
     default: 'output',
   })
-  .option('--no-cache', '캐시를 무시하고 GitHub API를 새로 호출합니다')
+  .option(
+    '--no-cache',
+    '설정 시 기존 캐시를 무시하고 전체 데이터를 새로 수집합니다',
+  )
   .option('--since <since>', '캐시 이후 증분 수집 기준 시점 ISO8601')
   .option('--sort-by <field>', '정렬 기준 (score, id)', {
     default: 'score',
@@ -371,5 +374,13 @@ cli
     },
   );
 
-cli.help();
+cli.help(sections => {
+  const optionsSection = sections.find(s => s.title === 'Options');
+  if (optionsSection && optionsSection.body) {
+    optionsSection.body = optionsSection.body.replace(
+      /(--no-cache.*?)\s*\(default:\s*true\)/,
+      '$1',
+    );
+  }
+});
 cli.parse();

--- a/index.ts
+++ b/index.ts
@@ -52,10 +52,9 @@ cli
   .option('--output-dir <path>', '결과 파일을 저장할 디렉터리', {
     default: 'output',
   })
-  .option(
-    '--no-cache',
-    '설정 시 기존 캐시를 무시하고 전체 데이터를 새로 수집합니다',
-  )
+  .option('--cache', '기존 캐시를 사용하여 데이터를 수집합니다 (캐시 무시: --no-cache)', {
+    default: true,
+  })
   .option('--since <since>', '캐시 이후 증분 수집 기준 시점 ISO8601')
   .option('--sort-by <field>', '정렬 기준 (score, id)', {
     default: 'score',
@@ -374,13 +373,5 @@ cli
     },
   );
 
-cli.help(sections => {
-  const optionsSection = sections.find(s => s.title === 'Options');
-  if (optionsSection && optionsSection.body) {
-    optionsSection.body = optionsSection.body.replace(
-      /(--no-cache.*?)\s*\(default:\s*true\)/,
-      '$1',
-    );
-  }
-});
+cli.help();
 cli.parse();

--- a/index.ts
+++ b/index.ts
@@ -52,9 +52,13 @@ cli
   .option('--output-dir <path>', '결과 파일을 저장할 디렉터리', {
     default: 'output',
   })
-  .option('--cache', '기존 캐시를 사용하여 데이터를 수집합니다 (캐시 무시: --no-cache)', {
-    default: true,
-  })
+  .option(
+    '--cache',
+    '기존 캐시를 사용하여 데이터를 수집합니다 (캐시 무시: --no-cache)',
+    {
+      default: true,
+    },
+  )
   .option('--since <since>', '캐시 이후 증분 수집 기준 시점 ISO8601')
   .option('--sort-by <field>', '정렬 기준 (score, id)', {
     default: 'score',


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #300 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] index.ts: 억지로 만든 --no-cache 옵션 대신 --cache 옵션(기본값 true)을 정의하여 cac 프레임워크의 부정형 옵션 자동 파싱 기능을 사용하도록 개선
- [ ] README.md: 변경된 CLI 옵션 설정에 맞추어 Synopsis 내용 업데이트

### 🧪 테스트 방법 (선택 사항)
터미널에서 bun run index.ts --help 명령어를 실행하여 옵션 목록에 --cache가 정상적으로 표시되고 기본값 안내가 자연스러운지 확인

터미널에서 bun run index.ts 저장소경로 --no-cache 명령어를 실행하여 콘솔에
"캐시를 무시하고 전체 데이터를 다시 수집합니다." 문구가 뜨며 정상 동작하는지 확인

### 💬 참고 사항 (선택 사항)
cac에 --no-cache 옵션을 사용시에는 뒤에 붙은 default 출력 을 없앨수 없습니다.
없애기 위해서는 help 출력시에 default 출력을 삭제하는 별도의 로직이 필요한데 이는 불필요한 동작이라고 생각됩니다.

해서 cache 옵션으로 설정하고 --no-cache 옵션도 받아들일수 있도록 작업을 진행했습니다.

이렇게 하면 뒤에 default 값이 붙더라고 cache 사용이라는 점을 사용자가 인지할수 있어 더 나은 방향성이라고 생각됩니다.
