### PR TITLE
--since 옵션 입력값의 ISO8601 날짜 형식 유효성 검증 파이프라인 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -194,6 +194,13 @@ cli
         );
       }
 
+      // [수정 포인트] --since 입력값이 존재할 때 ISO8601 날짜 규격 포맷 유효성 검증 예외 필터링 추가
+      if (since && Number.isNaN(Date.parse(since))) {
+        errors.push(
+          '오류: --since 값은 ISO8601 형식의 유효한 날짜 문자열이어야 합니다.',
+        );
+      }
+
       if (repos.length === 0) {
         errors.push(
           '오류: 최소 하나 이상의 저장소(owner/repo)를 입력해야 합니다.',
@@ -244,13 +251,8 @@ cli
         process.exit(1);
       }
 
-      // ── [개선] --claims 모드 병렬 처리 ──────────────────────────────────
-
       // --claims 옵션이 있으면 점수 계산 대신 이슈 선점 현황만 조회합니다.
       if (isClaimsMode) {
-        // 조회 실패 여부를 추적하는 플래그입니다.
-        // 루프 도중에 즉시 종료하지 않고 모든 저장소를 끝까지 처리한 뒤,
-        // 루프가 완전히 끝난 후 이 플래그를 확인하여 종료 코드를 결정합니다.
         let hasClaimFailure = false;
 
         for (const {repoPath, owner, repoName} of parsedRepos) {
@@ -281,7 +283,7 @@ cli
       logVerbose(`형식: ${formats.join(', ')}`);
       logVerbose(`저장소: ${repos.join(', ')}`);
 
-      // ── [개선] 일반 기여도 점수 산정 모드 병렬 처리 (Promise.allSettled) ──────
+      // 일반 기여도 점수 산정 모드 병렬 처리 (Promise.allSettled)
       const tasks = parsedRepos.map(async ({repoPath, owner, repoName}) => {
         const detailed = await githubService.getDetailedRepoData(
           owner,
@@ -320,7 +322,6 @@ cli
       const repoSummaries: RepoSummary[] = [];
       let hasFailure = false;
 
-      // 입력된 순서를 완벽하게 보장하며 순회 및 안전 분기 결합
       results.forEach((result, i) => {
         const {repoPath} = parsedRepos[i]!;
 
@@ -344,19 +345,16 @@ cli
         }
       });
 
-      // 단 하나의 저장소라도 통신에 실패했다면 수집 작업 안내 후 종료 코드로 즉시 반영
       if (hasFailure) {
         process.exit(1);
       }
 
-      // 모든 저장소 데이터를 합산하여 최종 사용자 점수를 계산합니다. (입력 순서가 보장된 리스트 활용)
       const userScores = sortUserScores(
         ScoreCalculator.calculateUserScores(repoDataList),
         sortBy as SupportedSortBy,
         sortOrder as SupportedSortOrder,
       );
 
-      // 합산된 사용자 점수와 저장소 요약 정보를 파일로 출력합니다.
       const written = await writeOutputFiles(
         formats as SupportedFormat[],
         {


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #317 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 **사전 유효성 검증 추가**: `--since` 옵션으로 입력된 문자열이 유효한 ISO8601 날짜 규격인지 데이터 수집 전에 미리 검증하는 로직을 도입했습니다.
- [ ] 변경 사항 2 **안정성 확보**: `Date.parse()` 연산 결과가 `NaN`인 예외 케이스를 안전하게 차단하여, 잘못된 데이터 형식이 내부 증분 조회 및 캐시 갱신 로직까지 전달되지 않도록 방어했습니다.
- [ ] 변경 사항 3 **일괄 오류 처리 통합**: 발생한 날짜 포맷 오류를 기존 `errors` 배열 시스템에 통합해 다른 옵션 오류들과 함께 정형화된 CLI 안내 문구로 출력되도록 개선했습니다.

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
