### PR TITLE
fix: claims 연결 PR 파싱 범위 제한

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -116,6 +116,29 @@ const PAGE_SIZE = 100;
 export const normalizeWhitespace = (text: string): string =>
   text.replace(/\s+/g, '').toLowerCase();
 
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
+const CLOSING_ISSUE_PATTERN =
+  /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+(?:#(\d+)|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+))\b/gi;
+
+/**
+ * PR 본문에서 실제 GitHub closing keyword가 붙은 이슈 번호만 추출합니다.
+ * PR 템플릿의 HTML 주석 예시 번호나 단순 참고용 #번호는 제외합니다.
+ */
+export const parseClosingIssueNumbers = (body: string): number[] => {
+  const issueNumbers = new Set<number>();
+  const bodyWithoutComments = body.replace(HTML_COMMENT_PATTERN, '');
+
+  for (const match of bodyWithoutComments.matchAll(CLOSING_ISSUE_PATTERN)) {
+    const issueNumber = Number(match[1] ?? match[2]);
+
+    if (Number.isInteger(issueNumber)) {
+      issueNumbers.add(issueNumber);
+    }
+  }
+
+  return [...issueNumbers];
+};
+
 /**
  * GitHub 라벨명을 내부 기여 카테고리로 정규화합니다.
  * @param label 정규화할 GitHub 라벨명
@@ -632,10 +655,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       const connection = response.repository.pullRequests;
 
       for (const pr of connection.nodes) {
-        const body = pr.body ?? '';
-        const matches = body.matchAll(/#(\d+)/g);
-        for (const match of matches) {
-          const issueNum = parseInt(match[1]!, 10);
+        const issueNumbers = parseClosingIssueNumbers(pr.body ?? '');
+        for (const issueNum of issueNumbers) {
           if (!issueToOpenPr.has(issueNum)) {
             issueToOpenPr.set(issueNum, {number: pr.number, url: pr.url});
           }

--- a/tests/github-service.test.ts
+++ b/tests/github-service.test.ts
@@ -1,6 +1,35 @@
 import {describe, expect, test, afterEach} from 'bun:test';
 
-import {normalizeWhitespace, categorizeLabels} from '../src/github-service';
+import {
+  normalizeWhitespace,
+  categorizeLabels,
+  parseClosingIssueNumbers,
+} from '../src/github-service';
+
+describe('open PR linked issue parsing', () => {
+  test('PR 템플릿 HTML 주석의 예시 이슈 번호는 연결 이슈로 처리하지 않는다', () => {
+    const body = `### ISSUE_ID
+<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
+Closes #319`;
+
+    expect(parseClosingIssueNumbers(body)).toEqual([319]);
+  });
+
+  test('closing keyword가 없는 단순 참고 번호는 연결 이슈로 처리하지 않는다', () => {
+    const body = `참고: #123
+관련 논의: #300`;
+
+    expect(parseClosingIssueNumbers(body)).toEqual([]);
+  });
+
+  test('GitHub closing keyword가 붙은 이슈 번호만 중복 없이 추출한다', () => {
+    const body = `Fixes #10
+Resolves #20
+Closed #10`;
+
+    expect(parseClosingIssueNumbers(body)).toEqual([10, 20]);
+  });
+});
 
 describe('claims keyword whitespace normalization', () => {
   test('선점 키워드의 공백 차이를 제거해 같은 문자열로 정규화한다', () => {


### PR DESCRIPTION
Closes #319

### 변경사항
- [x] `--claims`의 연결 PR 판단에서 모든 `#숫자`를 매칭하던 로직을 수정했습니다.
- [x] PR 템플릿 HTML 주석 안의 예시 이슈 번호가 연결 PR로 처리되지 않도록 했습니다.
- [x] `Closes`, `Fixes`, `Resolves` 등 실제 GitHub closing keyword가 붙은 이슈 번호만 추출하도록 변경했습니다.
- [x] PR 본문 이슈 번호 파싱 로직에 대한 단위 테스트를 추가했습니다.

### 🧪 테스트 방법

아래 명령어로 확인했습니다.

```bash
bun test tests/github-service.test.ts
bun run typecheck
bun test
bun run lint
```

확인 결과, PR 템플릿 주석의 예시 번호는 제외되고 실제 연결 문구인 `Closes #319`만 추출되는 것을 테스트로 검증했습니다.

### 💬 참고 사항

기존 로직은 PR 본문에 포함된 모든 `#숫자` 패턴을 연결 이슈 번호로 처리했습니다.

```ts
const matches = body.matchAll(/#(\d+)/g);
```

이로 인해 PR 템플릿 주석에 남아 있는 예시 번호도 실제 연결 이슈처럼 처리될 수 있었습니다.

```md
<!-- 관련된 이슈 ID를 입력해주세요 (예: # 123) -->
```

이번 PR에서는 HTML 주석을 먼저 제거하고, 실제 GitHub closing keyword가 붙은 이슈 번호만 연결 PR 판단에 사용하도록 변경했습니다.

예를 들어 다음 문구는 연결 이슈로 인정됩니다.

```md
Closes #319
Fixes #319
Resolves #319
```

반면 다음과 같은 템플릿 예시나 단순 참고 번호는 연결 이슈로 처리하지 않습니다.

```md
<!-- 관련된 이슈 ID를 입력해주세요 (예: # 123) -->
참고: # 123
관련 논의: # 300
```

이 PR은 `--claims` 기능 자체를 변경하지 않고, 연결 PR 판단 시 실제 closing keyword가 붙은 이슈 번호만 인정하도록 파싱 범위를 좁히는 수정입니다.