### PR TITLE
중복된 리포지토리 거부 로직 추가

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,27 +20,14 @@ import {
 } from './src/sort';
 import {type FullGitHubService} from './src/types';
 import {setVerbose, logVerbose} from './src/logger';
+import {
+  findDuplicateParsedRepos,
+  parseRepoPath,
+  type ParsedRepo,
+} from './src/repo-input';
 
 const cli = cac('reposcore-ts');
 cli.version(pkg.version);
-
-/**
- * 저장소 경로 문자열을 소유자와 저장소 이름으로 분리합니다.
- * @param repoPath owner/repo 형식의 저장소 경로
- * @returns 저장소 소유자와 이름 정보, 형식이 올바르지 않으면 null
- */
-function parseRepoPath(repoPath: string) {
-  const parts = repoPath.split('/');
-
-  if (parts.length !== 2 || !parts[0] || !parts[1]) {
-    return null;
-  }
-
-  return {
-    owner: parts[0],
-    repoName: parts[1],
-  };
-}
 
 cli
   .command('[...repos]', '대상 저장소 목록 (예: owner/repo1 owner/repo2)')
@@ -164,11 +151,7 @@ cli
         );
       }
 
-      const parsedRepos: {
-        repoPath: string;
-        owner: string;
-        repoName: string;
-      }[] = [];
+      const parsedRepos: ParsedRepo[] = [];
 
       // CLI 실행에 필요한 옵션과 입력값을 검증합니다.
       if (!token) {
@@ -238,6 +221,13 @@ cli
           owner: parsedRepo.owner,
           repoName: parsedRepo.repoName,
         });
+      }
+
+      const duplicateRepos = findDuplicateParsedRepos(parsedRepos);
+      for (const repo of duplicateRepos) {
+        errors.push(
+          `오류: 중복 저장소 '${repo.repoPath}'가 입력되었습니다. 같은 저장소는 한 번만 입력하세요.`,
+        );
       }
 
       // 검증 중 발견된 오류를 출력하고 실행을 중단합니다.

--- a/src/repo-input.ts
+++ b/src/repo-input.ts
@@ -1,0 +1,43 @@
+export interface ParsedRepo {
+  repoPath: string;
+  owner: string;
+  repoName: string;
+}
+
+export const getRepoKey = (
+  repo: Pick<ParsedRepo, 'owner' | 'repoName'>,
+): string => `${repo.owner.toLowerCase()}/${repo.repoName.toLowerCase()}`;
+
+export const parseRepoPath = (
+  repoPath: string,
+): Pick<ParsedRepo, 'owner' | 'repoName'> | null => {
+  const parts = repoPath.split('/');
+
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+
+  return {
+    owner: parts[0],
+    repoName: parts[1],
+  };
+};
+
+export const findDuplicateParsedRepos = (
+  repos: readonly ParsedRepo[],
+): ParsedRepo[] => {
+  const seen = new Set<string>();
+  const duplicateRepos: ParsedRepo[] = [];
+
+  for (const repo of repos) {
+    const key = getRepoKey(repo);
+    if (seen.has(key)) {
+      duplicateRepos.push(repo);
+      continue;
+    }
+
+    seen.add(key);
+  }
+
+  return duplicateRepos;
+};

--- a/tests/repo-input.test.ts
+++ b/tests/repo-input.test.ts
@@ -1,0 +1,52 @@
+import {describe, expect, test} from 'bun:test';
+import {
+  findDuplicateParsedRepos,
+  getRepoKey,
+  parseRepoPath,
+} from '../src/repo-input';
+
+describe('repo input helpers', () => {
+  test('parseRepoPath() accepts owner/repo format', () => {
+    expect(parseRepoPath('oss2026hnu/reposcore-ts')).toEqual({
+      owner: 'oss2026hnu',
+      repoName: 'reposcore-ts',
+    });
+  });
+
+  test('parseRepoPath() rejects malformed repo paths', () => {
+    expect(parseRepoPath('oss2026hnu')).toBeNull();
+    expect(parseRepoPath('oss2026hnu/reposcore-ts/extra')).toBeNull();
+    expect(parseRepoPath('/reposcore-ts')).toBeNull();
+    expect(parseRepoPath('oss2026hnu/')).toBeNull();
+  });
+
+  test('getRepoKey() normalizes owner and repo name casing', () => {
+    expect(getRepoKey({owner: 'OSS2026HNU', repoName: 'RepoScore-TS'})).toBe(
+      'oss2026hnu/reposcore-ts',
+    );
+  });
+
+  test('findDuplicateParsedRepos() reports duplicate repository inputs', () => {
+    const repos = [
+      {
+        repoPath: 'oss2026hnu/reposcore-ts',
+        owner: 'oss2026hnu',
+        repoName: 'reposcore-ts',
+      },
+      {
+        repoPath: 'OSS2026HNU/RepoScore-TS',
+        owner: 'OSS2026HNU',
+        repoName: 'RepoScore-TS',
+      },
+      {
+        repoPath: 'oss2026hnu/reposcore-cs',
+        owner: 'oss2026hnu',
+        repoName: 'reposcore-cs',
+      },
+    ];
+
+    const result = findDuplicateParsedRepos(repos);
+
+    expect(result).toEqual([repos[1]!]);
+  });
+});


### PR DESCRIPTION
### ISSUE_ID
Closes #314

### Changes
- [x] 저장소 입력 파싱 및 정규화 유틸을 추가했습니다.
- [x] 동일 저장소가 여러 번 입력되면 validation 오류로 처리하도록 했습니다.
- [x] 중복 저장소 입력이 발견되면 GitHub 조회와 점수 분석을 시작하지 않고 비정상 종료하도록 했습니다.
- [x] 대소문자가 다른 동일 저장소 입력도 중복으로 감지하는 테스트를 추가했습니다.

### Test
- [x] `npx tsc --noEmit`
- [x] `npx --yes bun test`
- [x] `npx eslint index.ts src/score-calculator.ts src/repo-input.ts tests/repo-input.test.ts tests/score-calculator.test.ts --fix-dry-run`
- [x] `npx --yes bun run index.ts oss2026hnu/reposcore-ts OSS2026HNU/RepoScore-TS --token fake --format csv --output-dir <temp>`

### Notes
- 중복 저장소 CLI 검증에서는 exit code 1과 출력 디렉터리 미생성을 확인했습니다.
- `npx gts lint`는 Windows checkout의 CRLF 줄끝을 repo 전체 파일에서 Prettier 오류로 보고하여 실패했습니다. 변경 파일 대상의 ESLint dry-run은 통과했습니다.
