### PR TITLE
저장소 검증 단계의 GitHub API 인증 오류를 사용자 친화적으로 처리 (#324)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import {cac} from 'cac';
 import pkg from './package.json' with {type: 'json'};
 
-import {createGitHubService} from './src/github-service';
+import {createGitHubService, formatGitHubApiError} from './src/github-service';
 import {ScoreCalculator, type RepoData} from './src/score-calculator';
 import {
   summarizeRepo,
@@ -256,9 +256,14 @@ cli
       ) as FullGitHubService;
 
       // 실제 데이터 수집 전에 모든 저장소가 GitHub에 존재하는지 한 번에 검증합니다.
-      const missingRepos =
-        await githubService.validateRepositoriesExist(parsedRepos);
-
+      let missingRepos: string[];
+      try {
+        missingRepos =
+          await githubService.validateRepositoriesExist(parsedRepos);
+      } catch (error) {
+        console.error(formatGitHubApiError(error));
+        process.exit(1);
+      }
       if (missingRepos.length > 0) {
         for (const repoPath of missingRepos) {
           console.error(

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -113,6 +113,28 @@ interface GetDetailedRepoDataOptions {
 
 const PAGE_SIZE = 100;
 
+/**
+ * GitHub API 호출 중 발생한 오류를 사용자 친화적인 메시지로 변환합니다.
+ * 인증 실패(401)와 요청 한도 초과(403/429)는 구체적인 안내로,
+ * 그 외 오류는 raw 스택 트레이스 대신 정리된 메시지로 변환합니다.
+ * @param error 발생한 오류 객체
+ * @returns 사용자에게 출력할 오류 메시지
+ */
+export const formatGitHubApiError = (error: unknown): string => {
+  const status = (error as {status?: number} | null)?.status;
+
+  if (status === 401) {
+    return '오류: GitHub API 인증에 실패했습니다. GITHUB_TOKEN 또는 --token 값을 확인하세요. (Status: 401)';
+  }
+
+  if (status === 403 || status === 429) {
+    return `오류: GitHub API 요청 한도를 초과했습니다. 잠시 후 다시 시도하세요. (Status: ${status})`;
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return `오류: 저장소 검증 중 GitHub API 오류가 발생했습니다. (${message})`;
+};
+
 export const normalizeWhitespace = (text: string): string =>
   text.replace(/\s+/g, '').toLowerCase();
 

--- a/tests/github-service.test.ts
+++ b/tests/github-service.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeWhitespace,
   categorizeLabels,
   parseClosingIssueNumbers,
+  formatGitHubApiError,
 } from '../src/github-service';
 
 describe('open PR linked issue parsing', () => {
@@ -330,5 +331,30 @@ describe('claims doc 라벨 24h 기한 필터', () => {
     expect(issueCategory).toBe('doc');
     expect(CLAIM_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
     expect(matchedClaim).toBeNull();
+  });
+});
+
+describe('GitHub API 오류 메시지 변환', () => {
+  test('401 오류는 인증 실패 메시지로 변환한다', () => {
+    const error = Object.assign(new Error('Bad credentials'), {status: 401});
+    const message = formatGitHubApiError(error);
+    expect(message).toContain('인증에 실패');
+    expect(message).toContain('401');
+  });
+
+  test('403/429 오류는 요청 한도 메시지로 변환한다', () => {
+    expect(
+      formatGitHubApiError(Object.assign(new Error('x'), {status: 403})),
+    ).toContain('요청 한도');
+    expect(
+      formatGitHubApiError(Object.assign(new Error('x'), {status: 429})),
+    ).toContain('요청 한도');
+  });
+
+  test('raw HttpError 스택 트레이스를 그대로 노출하지 않는다', () => {
+    const error = Object.assign(new Error('Bad credentials'), {status: 401});
+    const message = formatGitHubApiError(error);
+    expect(message).not.toContain('HttpError');
+    expect(message.startsWith('오류:')).toBe(true);
   });
 });


### PR DESCRIPTION
### ISSUE_ID
Closes #324

### 변경사항
- [x] 저장소 존재 검증(`validateRepositoriesExist`) 호출을 `try/catch`로 감싸 API 오류를 처리
- [x] GitHub API 오류를 사용자 친화적 메시지로 변환하는 `formatGitHubApiError` 추가 (401 인증 실패 / 403·429 요청 한도 / 그 외 정리된 메시지)
- [x] 잘못된 토큰 입력 시 raw `HttpError`가 노출되지 않음을 확인하는 테스트 추가

### 🧪 테스트 방법 (선택 사항)
잘못된 토큰으로 실행 시 raw 스택 트레이스 대신 정리된 인증 오류 메시지가 출력되고 종료되는지 확인했습니다.

```bash
bun run index.ts oss2026hnu/reposcore-ts --token dummy-token --no-cache
# 기대 출력:
# 오류: GitHub API 인증에 실패했습니다. GITHUB_TOKEN 또는 --token 값을 확인하세요. (Status: 401)
```

`bun run lint`, `bun run typecheck`, `bun test` 모두 통과를 확인했습니다.

### 💬 참고 사항 (선택 사항)
- 이 PR은 저장소 존재 검증 기능 자체를 제거하지 않으며, 검증 단계에서 발생하는 인증/한도 오류의 사용자 노출 방식만 개선합니다.
- `--claims` 모드도 동일한 검증 단계를 거치므로 함께 보호됩니다.
- CLI 옵션 변경이 없어 `make synopsis`/`make docs` 재생성은 필요하지 않습니다.