### PR TITLE
--no-cache 실행 후에도 캐시 파일이 생성되지 않도록 수정

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -593,7 +593,9 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
         issues,
       };
 
-      await saveCache(owner, repo, data, analysisStartedAt);
+      if (useCache) {
+        await saveCache(owner, repo, data, analysisStartedAt);
+      }
 
       return data;
     }
@@ -610,7 +612,9 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       issues: mergeByNumber(cached.data.issues, updatedIssues),
     };
 
-    await saveCache(owner, repo, data, analysisStartedAt);
+    if (useCache) {
+      await saveCache(owner, repo, data, analysisStartedAt);
+    }
 
     return data;
   };
@@ -855,13 +859,15 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       openIssues = mergeByNumber(filteredCached, openUpdated);
     }
 
-    await saveCache<ClaimsData>(
-      owner,
-      repo,
-      {issues: openIssues},
-      analysisStartedAt,
-      'claims-cache',
-    );
+    if (useCache) {
+      await saveCache<ClaimsData>(
+        owner,
+        repo,
+        {issues: openIssues},
+        analysisStartedAt,
+        'claims-cache',
+      );
+    }
 
     const claimed: ClaimInfo[] = [];
     const unclaimed: ClaimInfo[] = [];


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #325 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] `--no-cache` 옵션이 지정된 경우, 기존 캐시를 읽지 않을 뿐만 아니라 실행 결과도 캐시에 저장하지 않도록 수정했습니다. 이를 통해 캐시를 완전히 사용하지 않겠다는 사용자의 의도와 일치하도록 동작을 개선했습니다.


### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
   ```bash
   bun run index.ts oss2026hnu/reposcore-ts --token $GITHUB_TOKEN --no-cache
   ```
   
### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
