### PR TITLE
fix: 캐시가 없거나 no-cache일 때 since 옵션이 무시되는 버그 수정

### DIFF
--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -117,9 +117,11 @@ export const normalizeWhitespace = (text: string): string =>
   text.replace(/\s+/g, '').toLowerCase();
 
 // [긴급 조치] 복사 인코딩 오류 및 개행 문자 깨짐을 우회하기 위해 정규식을 안전한 RegExp 생성자 문자열 구조로 전면 전향
-const HTML_COMMENT_PATTERN = new RegExp('', 'g');
-const CLOSING_ISSUE_PATTERN = new RegExp('\\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\\s+(?:#(\\d+)|https://github\\.com/[^/\\s]+/[^/\\s]+/issues/(\\d+))\\b', 'gi');
-
+const HTML_COMMENT_PATTERN = new RegExp('<!--[\\s\\S]*?-->', 'g');
+const CLOSING_ISSUE_PATTERN = new RegExp(
+  '\\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\\s+(?:#(\\d+)|https://github\\.com/[^/\\s]+/[^/\\s]+/issues/(\\d+))\\b',
+  'gi',
+);
 /**
  * PR 본문에서 실제 GitHub closing keyword가 붙은 이슈 번호만 추출합니다.
  * PR 템플릿의 HTML 주석 예시 번호나 단순 참고용 #번호는 제외합니다.

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -116,9 +116,9 @@ const PAGE_SIZE = 100;
 export const normalizeWhitespace = (text: string): string =>
   text.replace(/\s+/g, '').toLowerCase();
 
-const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
-const CLOSING_ISSUE_PATTERN =
-  /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+(?:#(\d+)|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+))\b/gi;
+// [긴급 조치] 복사 인코딩 오류 및 개행 문자 깨짐을 우회하기 위해 정규식을 안전한 RegExp 생성자 문자열 구조로 전면 전향
+const HTML_COMMENT_PATTERN = new RegExp('', 'g');
+const CLOSING_ISSUE_PATTERN = new RegExp('\\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\\s+(?:#(\\d+)|https://github\\.com/[^/\\s]+/[^/\\s]+/issues/(\\d+))\\b', 'gi');
 
 /**
  * PR 본문에서 실제 GitHub closing keyword가 붙은 이슈 번호만 추출합니다.
@@ -582,10 +582,15 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     const analysisStartedAt = new Date().toISOString();
     const cached = await loadCache<DetailedRepoData>(owner, repo, !useCache);
 
+    // [버그 수정 완료 블록] 캐시가 없는 상태이거나 --no-cache 일 때 options.since를 검사하여 데이터 필터링 적용
     if (!cached) {
       const [issues, prs] = await Promise.all([
-        getAllValidIssues(owner, repo),
-        getAllMergedPullRequests(owner, repo),
+        options?.since
+          ? getUpdatedValidIssues(owner, repo, options.since)
+          : getAllValidIssues(owner, repo),
+        options?.since
+          ? getUpdatedMergedPullRequests(owner, repo, options.since)
+          : getAllMergedPullRequests(owner, repo),
       ]);
 
       const data: DetailedRepoData = {
@@ -598,6 +603,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       return data;
     }
 
+    // 캐시가 존재할 때 기존 점진적 수집 흐름
     const since = options?.since ?? cached.lastAnalyzedAt;
 
     const [updatedIssues, updatedPrs] = await Promise.all([
@@ -954,13 +960,11 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     try {
       data = await githubGraphQL<ExistenceData>(query, variables);
     } catch (error: unknown) {
-      // NOT_FOUND 등 errors가 있어도 부분 데이터는 error.data에 담겨 옴
       const partial = (error as {data?: ExistenceData}).data;
       if (!partial) throw error;
       data = partial;
     }
 
-    // 응답이 null인 저장소 = 존재하지 않거나 접근 불가
     return repos.filter((_, i) => !data[`r${i}`]).map(repo => repo.repoPath);
   };
 


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
Closes #323 

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 캐시가 없거나 --no-cache인 실행 경로에서 --since 옵션(날짜 필터)이 적용되지 않던 버그를 수정했습니다.
- [ ] 변경 사항 2 캐시 유무와 관계없이 동일한 --since 조건이 주어지면 언제나 해당 날짜 이후의 기여 데이터만 필터링하여 수집하도록 개선했습니다.
- [ ] 변경 사항 3 특수 문자 인코딩 및 개행으로 인한 구문 파싱 에러를 방지하기 위해, 내부 정규식 패턴 선언 구조를 안전한 RegExp 생성자 방식으로 보완했습니다.

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
