### PR TITLE
선점 댓글 누락 문제 수정

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -121,6 +121,7 @@ cli
       // undefined(옵션 미지정)와 ['true'](값 없는 --keywords) 모두 기본 키워드로 폴백합니다.
       const isDefaultFallback =
         options.keywords === undefined ||
+        String(options.keywords) === 'undefined' ||
         (Array.isArray(options.keywords) &&
           options.keywords.length === 1 &&
           options.keywords[0] === 'true');

--- a/src/github-service.ts
+++ b/src/github-service.ts
@@ -21,13 +21,6 @@ interface ClaimsPageResponse {
         title: string;
         url: string;
         labels: {nodes: {name: string}[]};
-        comments: {
-          nodes: {
-            body: string;
-            author: {login: string} | null;
-            createdAt: string;
-          }[];
-        };
       }[];
       pageInfo: PageInfo;
     };
@@ -55,13 +48,6 @@ interface ClaimsSearchResponse {
       url: string;
       state: string;
       labels: {nodes: {name: string}[]};
-      comments: {
-        nodes: {
-          body: string;
-          author: {login: string} | null;
-          createdAt: string;
-        }[];
-      };
     }>;
     pageInfo: PageInfo;
   };
@@ -73,6 +59,23 @@ type RawPullRequest = Omit<PRRecord, 'category'>;
 interface PageInfo {
   hasNextPage: boolean;
   endCursor: string | null;
+}
+
+type ClaimCommentNode = {
+  body: string;
+  author: {login: string} | null;
+  createdAt: string;
+};
+
+interface IssueCommentsPageResponse {
+  repository: {
+    issue: {
+      comments: {
+        nodes: ClaimCommentNode[];
+        pageInfo: PageInfo;
+      };
+    };
+  };
 }
 
 interface IssuePageResponse {
@@ -710,6 +713,58 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     return issueToOpenPr;
   };
 
+  const getAllIssueComments = async (
+    owner: string,
+    repo: string,
+    issueNumber: number,
+  ): Promise<ClaimCommentNode[]> => {
+    const comments: ClaimCommentNode[] = [];
+    let cursor: string | null = null;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+      const response: IssueCommentsPageResponse =
+        await githubGraphQL<IssueCommentsPageResponse>(
+          `
+        query(
+          $owner: String!
+          $repo: String!
+          $issueNumber: Int!
+          $pageSize: Int!
+          $cursor: String
+        ) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $issueNumber) {
+              comments(first: $pageSize, after: $cursor) {
+                nodes {
+                  body
+                  author { login }
+                  createdAt
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+        `,
+          {owner, repo, issueNumber, pageSize, cursor},
+        );
+
+      const connection: IssueCommentsPageResponse['repository']['issue']['comments'] =
+        response.repository.issue.comments;
+
+      comments.push(...connection.nodes);
+
+      cursor = connection.pageInfo.endCursor;
+      hasNextPage = connection.pageInfo.hasNextPage && cursor !== null;
+    }
+
+    return comments;
+  };
+
   /**
    * 저장소의 열린 이슈와 최근 댓글을 모두 조회합니다 (전체 조회).
    * @param owner 저장소 소유자
@@ -720,7 +775,7 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     owner: string,
     repo: string,
   ): Promise<ClaimsIssueNode[]> => {
-    const issues: ClaimsIssueNode[] = [];
+    const issues: Omit<ClaimsIssueNode, 'comments'>[] = [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -736,13 +791,6 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
                   title
                   url
                   labels(first: 20) { nodes { name } }
-                  comments(last: 10) {
-                    nodes {
-                      body
-                      author { login }
-                      createdAt
-                    }
-                  }
                 }
                 pageInfo {
                   hasNextPage
@@ -762,7 +810,14 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       hasNextPage = connection.pageInfo.hasNextPage && cursor !== null;
     }
 
-    return issues;
+    return Promise.all(
+      issues.map(async issue => ({
+        ...issue,
+        comments: {
+          nodes: await getAllIssueComments(owner, repo, issue.number),
+        },
+      })),
+    );
   };
 
   /**
@@ -777,7 +832,8 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
     repo: string,
     since: string,
   ): Promise<Array<ClaimsIssueNode & {state: string}>> => {
-    const issues: Array<ClaimsIssueNode & {state: string}> = [];
+    const issues: Array<Omit<ClaimsIssueNode, 'comments'> & {state: string}> =
+      [];
     let cursor: string | null = null;
     let hasNextPage = true;
 
@@ -794,13 +850,6 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
                   url
                   state
                   labels(first: 20) { nodes { name } }
-                  comments(last: 10) {
-                    nodes {
-                      body
-                      author { login }
-                      createdAt
-                    }
-                  }
                 }
               }
               pageInfo {
@@ -823,7 +872,14 @@ export const createGitHubService = (token: string, pageSize = PAGE_SIZE) => {
       hasNextPage = response.search.pageInfo.hasNextPage && cursor !== null;
     }
 
-    return issues;
+    return Promise.all(
+      issues.map(async issue => ({
+        ...issue,
+        comments: {
+          nodes: await getAllIssueComments(owner, repo, issue.number),
+        },
+      })),
+    );
   };
 
   /**


### PR DESCRIPTION
### ISSUE_ID
Closes https://github.com/oss2026hnu/reposcore-ts/issues/332

### 변경사항
- [x] ```--claims``` 조회 시 이슈 댓글을 최근 10개만 가져오던 ```comments(last: 10)``` 구조를 제거했습니다.
- [x] 이슈 댓글을 페이지네이션으로 조회하는 ```getAllIssueComments()``` 함수를 추가하여, 댓글 수가 10개를 초과하는 경우에도 모든 댓글을 조회할 수 있도록 수정했습니다.
- [x] 전체 조회 경로(```getAllOpenIssuesWithComments```)과 증분 조회 경로(```getUpdatedIssuesWithComments```)에 댓글 전체 조회 로직을 적용했습니다.

### 🧪 테스트 방법 (선택 사항)
- bun run lint 실행
- bun run test 실행
- bun run index.ts oss2026hnu/reposcore-ts --claims --no-cache 실행 후, 정상 동작 확인

### 💬 참고 사항 (선택 사항)
- 단순히 조회 개수만 늘리는 방식으로는 해당 개수를 초과하면 동일한 문제가 다시 발생할 수 있다고 판단하여, GitHub GraphQL 댓글 connection에 페이지네이션을 적용하여 댓글 수와 관계없이 모든 댓글을 조회하도록 변경했습니다.
- 테스트 과정에서 ```--keywords``` 미지정 시 기본 키워드가 정상적으로 적용되지 않아 선점 댓글을 인식하지 못하는 문제를 발견하여 함께 수정했습니다.